### PR TITLE
#13 Disallow linear arrows in kinds

### DIFF
--- a/compiler/typecheck/TcHsType.hs
+++ b/compiler/typecheck/TcHsType.hs
@@ -548,8 +548,11 @@ tc_hs_type _ ty@(HsSpliceTy {}) _exp_kind
   = failWithTc (text "Unexpected type splice:" <+> ppr ty)
 
 ---------- Functions and applications
-tc_hs_type mode (HsFunTy ty1 weight ty2) exp_kind
-  = tc_fun_type mode weight ty1 ty2 exp_kind
+tc_hs_type mode ty@(HsFunTy ty1 weight ty2) exp_kind
+  | mode_level mode == KindLevel && not (weight == Omega)
+    = failWithTc (text "Linear arrows disallowed in kinds:" <+> ppr ty)
+  | otherwise
+    = tc_fun_type mode weight ty1 ty2 exp_kind
 
 tc_hs_type mode (HsOpTy ty1 (L _ op) ty2) exp_kind
   | op `hasKey` funTyConKey


### PR DESCRIPTION
Fix for issue #13 providing an error message on an attempted use of linear arrows in kind signatures.
Using the same test case as in the issue:
```
{-# LANGUAGE KindSignatures #-}
data NormalType :: * -> *
data LinType :: * ⊸ *
class NormalClass (t :: * -> *)
class LinClass (t :: * ⊸ *)
instance NormalClass LinType
instance LinClass NormalType
```
You now get an error:
```
linear_kinds.hs:3:17: error:
    • Linear arrows disallowed in kinds: * ⊸ *
    • In the kind ‘* ⊸ *’
  |
3 | data LinType :: * ⊸ *
  |                 ^^^^^
```
You don't get an error about the other improper use yet, but that changes if you remove the first site:
```
linear_kinds.hs:4:22: error:
    • Linear arrows disallowed in kinds: * ⊸ *
    • In the kind ‘* ⊸ *’
  |
4 | class LinClass (t :: * ⊸ *)
  |                      ^^^^^
```
If there's some way that I should've made the error to facilitate this, please tell me.  (It reports multiple at once for other similarly-generated errors, like [strictness annotations on higher-kinded types](https://github.com/tweag/ghc/blob/linear-types/compiler/typecheck/TcHsType.hs#L524-L528), e.g. `(!Maybe)`.)