### PR TITLE
Fix function type display in error messages

### DIFF
--- a/compiler/hsSyn/HsTypes.hs
+++ b/compiler/hsSyn/HsTypes.hs
@@ -1335,7 +1335,7 @@ ppr_fun_ty ctxt_prec ty1 weight ty2
         arr = case weight of
           Zero -> "->_0"
           One -> "⊸"
-          Omega -> "ω"
+          Omega -> "->"
     in
     maybeParen ctxt_prec FunPrec $
     sep [p1, text arr <+> p2]


### PR DESCRIPTION
Previously, it showed normal arrows as `ω` in error messages.  I didn't make a bug report because I though it would be easiest to just fix it.