### PR TITLE
Don't discard usage information from RHS of let bound variables

### DIFF
--- a/compiler/coreSyn/CoreLint.hs
+++ b/compiler/coreSyn/CoreLint.hs
@@ -768,7 +768,7 @@ lintCoreExpr (Let (NonRec bndr rhs) body)
                   lintCoreExpr body)
         ; let l_weight = idWeight bndr
         ; checkLinearity body_ue bndr
-        ; return (body_ty, body_ue `addUE` (l_weight `scaleUE` body_ue))}
+        ; return (body_ty, body_ue `addUE` (l_weight `scaleUE` let_ue))}
 
   | otherwise
   = failWithL (mkLetErr bndr rhs)       -- Not quite accurate


### PR DESCRIPTION
Fixes CatPairs test and probably many others.

Fixes #49