### PR TITLE
Keep track of weight in MatchGroup

### DIFF
--- a/compiler/basicTypes/Id.hs
+++ b/compiler/basicTypes/Id.hs
@@ -55,7 +55,7 @@ module Id (
         zapLamIdInfo, zapIdDemandInfo, zapIdUsageInfo, zapIdUsageEnvInfo,
         zapIdUsedOnceInfo, zapIdTailCallInfo,
         zapFragileIdInfo, zapIdStrictness, zapStableUnfolding,
-        transferPolyIdInfo,
+        transferPolyIdInfo, scaleIdBy,
 
         -- ** Predicates on Ids
         isImplicitId, isDeadBinder,
@@ -192,6 +192,9 @@ idWeight :: HasCallStack => Id -> Rig
 idWeight x =
  -- pprTrace "idWeight" (ppr x <+> ppr (Var.varWeightMaybe x) <+> callStackDoc) $
   Var.varWeight x
+
+scaleIdBy :: Id -> Rig -> Id
+scaleIdBy = Var.scaleVarBy
 
 setIdName :: Id -> Name -> Id
 setIdName = Var.setVarName

--- a/compiler/basicTypes/Var.hs
+++ b/compiler/basicTypes/Var.hs
@@ -46,7 +46,7 @@ module Var (
 
         -- ** Modifying 'Var's
         setVarName, setVarUnique, setVarType, updateVarType,
-        updateVarTypeM,
+        updateVarTypeM, scaleVarBy,
 
         -- ** Constructing, taking apart, modifying 'Id's
         mkGlobalVar, mkLocalVar, mkExportedLocalVar, mkCoVar,
@@ -389,6 +389,9 @@ varWeightMaybe _ = Nothing
 
 varWeightDef :: Id -> Rig
 varWeightDef = fromMaybe Omega . varWeightMaybe
+
+scaleVarBy :: Id -> Rig -> Id
+scaleVarBy id r = id { varWeight = r * (varWeight id) }
 
 {- *********************************************************************
 *                                                                      *

--- a/compiler/deSugar/DsArrows.hs
+++ b/compiler/deSugar/DsArrows.hs
@@ -605,7 +605,7 @@ dsCmd ids local_vars stack_ty res_ty
                          (MG { mg_alts = L l matches'
                              , mg_arg_tys = arg_tys
                              , mg_res_ty = sum_ty, mg_origin = origin
-                             , mg_weight = Omega })) -- TODO: MattP
+                             , mg_weight = Omega })) -- TODO: MattP check this multiplicity is correct
         -- Note that we replace the HsCase result type by sum_ty,
         -- which is the type of matches'
 

--- a/compiler/deSugar/DsArrows.hs
+++ b/compiler/deSugar/DsArrows.hs
@@ -604,7 +604,8 @@ dsCmd ids local_vars stack_ty res_ty
     core_body <- dsExpr (HsCase noExt exp
                          (MG { mg_alts = L l matches'
                              , mg_arg_tys = arg_tys
-                             , mg_res_ty = sum_ty, mg_origin = origin }))
+                             , mg_res_ty = sum_ty, mg_origin = origin
+                             , mg_weight = Omega })) -- TODO: MattP
         -- Note that we replace the HsCase result type by sum_ty,
         -- which is the type of matches'
 

--- a/compiler/deSugar/DsExpr.hs
+++ b/compiler/deSugar/DsExpr.hs
@@ -216,7 +216,7 @@ dsUnliftedBind (PatBind {pat_lhs = pat, pat_rhs = grhss
              eqn = EqnInfo { eqn_pats = [upat],
                              eqn_rhs = cantFailMatchResult body }
        ; var    <- selectMatchVar Omega upat -- TODO: MattP
-       ; result <- matchEquations PatBindRhs [var] [eqn] (exprType body) Omega -- MattP: TODO
+       ; result <- matchEquations PatBindRhs [var] [eqn] (exprType body) Omega -- MattP: TODO check this multiplicity.
        ; return (bindNonRec var rhs result) }
 
 dsUnliftedBind bind body = pprPanic "dsLet: unlifted" (ppr bind $$ ppr body)
@@ -634,7 +634,7 @@ ds_expr _ expr@(RecordUpd { rupd_expr = record_expr, rupd_flds = fields
                                                    , mg_arg_tys = [unrestricted in_ty] -- TODO: arnaud: haven't thought of the rules for record update
                                                    , mg_res_ty = out_ty
                                                    , mg_origin = FromSource
-                                                   , mg_weight = Omega }) -- MatP: TODO
+                                                   , mg_weight = Omega }) -- MattP: TODO Check this multiplicity
                                                    -- FromSource is not strictly right, but we
                                                    -- want incomplete pattern-match warnings
 
@@ -959,7 +959,7 @@ dsDo stmts
                       , mg_arg_tys = map unrestricted arg_tys
                       , mg_res_ty = body_ty
                       , mg_origin = Generated
-                      , mg_weight = Omega }
+                      , mg_weight = Omega } -- TODO: MattP: Check this multiplicity
 
            ; fun' <- dsLExpr fun
            ; let mk_ap_call l (op,r) = dsSyntaxExpr op [l,r]
@@ -992,7 +992,7 @@ dsDo stmts
                                                     [mfix_pat] body]
                                , mg_arg_tys = [unrestricted tup_ty], mg_res_ty = body_ty
                                , mg_origin = Generated
-                               , mg_weight = Omega })
+                               , mg_weight = Omega }) -- TODO: MattP: check this multiplicity
         mfix_pat     = noLoc $ LazyPat noExt $ mkBigLHsPatTupId rec_tup_pats
         body         = noLoc $ HsDo body_ty
                                 DoExpr (noLoc (rec_stmts ++ [ret_stmt]))

--- a/compiler/deSugar/DsExpr.hs
+++ b/compiler/deSugar/DsExpr.hs
@@ -215,8 +215,8 @@ dsUnliftedBind (PatBind {pat_lhs = pat, pat_rhs = grhss
        ; let upat = unLoc pat
              eqn = EqnInfo { eqn_pats = [upat],
                              eqn_rhs = cantFailMatchResult body }
-       ; var    <- selectMatchVar upat
-       ; result <- matchEquations PatBindRhs [var] [eqn] (exprType body)
+       ; var    <- selectMatchVar Omega upat -- TODO: MattP
+       ; result <- matchEquations PatBindRhs [var] [eqn] (exprType body) Omega -- MattP: TODO
        ; return (bindNonRec var rhs result) }
 
 dsUnliftedBind bind body = pprPanic "dsLet: unlifted" (ppr bind $$ ppr body)
@@ -632,7 +632,9 @@ ds_expr _ expr@(RecordUpd { rupd_expr = record_expr, rupd_flds = fields
         ; ([discrim_var], matching_code)
                 <- matchWrapper RecUpd Nothing (MG { mg_alts = noLoc alts
                                                    , mg_arg_tys = [unrestricted in_ty] -- TODO: arnaud: haven't thought of the rules for record update
-                                                   , mg_res_ty = out_ty, mg_origin = FromSource })
+                                                   , mg_res_ty = out_ty
+                                                   , mg_origin = FromSource
+                                                   , mg_weight = Omega }) -- MatP: TODO
                                                    -- FromSource is not strictly right, but we
                                                    -- want incomplete pattern-match warnings
 
@@ -956,7 +958,8 @@ dsDo stmts
                                                        body']
                       , mg_arg_tys = map unrestricted arg_tys
                       , mg_res_ty = body_ty
-                      , mg_origin = Generated }
+                      , mg_origin = Generated
+                      , mg_weight = Omega }
 
            ; fun' <- dsLExpr fun
            ; let mk_ap_call l (op,r) = dsSyntaxExpr op [l,r]
@@ -988,7 +991,8 @@ dsDo stmts
                                                     LambdaExpr
                                                     [mfix_pat] body]
                                , mg_arg_tys = [unrestricted tup_ty], mg_res_ty = body_ty
-                               , mg_origin = Generated })
+                               , mg_origin = Generated
+                               , mg_weight = Omega })
         mfix_pat     = noLoc $ LazyPat noExt $ mkBigLHsPatTupId rec_tup_pats
         body         = noLoc $ HsDo body_ty
                                 DoExpr (noLoc (rec_stmts ++ [ret_stmt]))

--- a/compiler/deSugar/DsUtils.hs
+++ b/compiler/deSugar/DsUtils.hs
@@ -98,7 +98,11 @@ otherwise, make one up.
 -}
 
 selectSimpleMatchVarL :: LPat GhcTc -> DsM Id
-selectSimpleMatchVarL pat = selectMatchVar Omega (unLoc pat) -- TODO: MattP
+selectSimpleMatchVarL pat = selectMatchVar Omega (unLoc pat)
+-- TODO: MattP: This function is used in a few places where is might be
+-- necessary to take into account multiplicity but it wasn't on the
+-- critical path to fix for now.
+
 
 -- (selectMatchVars ps tys) chooses variables of type tys
 -- to use for matching ps against.  If the pattern is a variable,
@@ -126,9 +130,7 @@ selectMatchVar w (ParPat _ pat)  = selectMatchVar w (unLoc pat)
 selectMatchVar w (VarPat _ var)  = return (localiseId (unLoc var))
                                   -- Note [Localise pattern binders]
 selectMatchVar w (AsPat _ var _) = return (unLoc var)
-selectMatchVar w other_pat     =
-    newSysLocalDsNoLP w (hsPatType other_pat) -- TODO: arnaud: I'm pretty sure I actually need to take the multiplicity of the pattern as an argument, though not knowing what the variable is used for, I don't know how I would use it quite yet
-                                  -- OK, better make up one...
+selectMatchVar w other_pat     = newSysLocalDsNoLP w (hsPatType other_pat)
 
 {-
 Note [Localise pattern binders]

--- a/compiler/deSugar/Match.hs-boot
+++ b/compiler/deSugar/Match.hs-boot
@@ -8,9 +8,11 @@ import CoreSyn  ( CoreExpr )
 import HsSyn    ( LPat, HsMatchContext, MatchGroup, LHsExpr )
 import Name     ( Name )
 import HsExtension ( GhcTc )
+import Weight   ( Rig )
 
 match   :: [Id]
         -> Type
+        -> Rig
         -> [EquationInfo]
         -> DsM MatchResult
 

--- a/compiler/deSugar/MatchCon.hs
+++ b/compiler/deSugar/MatchCon.hs
@@ -97,7 +97,6 @@ matchConFamily :: [Id]
 matchConFamily (var:vars) ty weight groups
   = do dflags <- getDynFlags
        alts <- mapM (fmap toRealAlt . matchOneConLike vars ty weight) groups
-       pprTrace "matchConfamily" (ppr var $$ ppr ty $$ ppr groups) (return ())
        return (mkCoAlgCaseMatchResult dflags var ty alts)
   where
     toRealAlt alt = case alt_pat alt of

--- a/compiler/deSugar/MatchLit.hs
+++ b/compiler/deSugar/MatchLit.hs
@@ -343,10 +343,11 @@ tidyNPat _ over_lit mb_neg eq outer_ty
 
 matchLiterals :: [Id]
               -> Type                   -- Type of the whole case expression
+              -> Rig
               -> [[EquationInfo]]       -- All PgLits
               -> DsM MatchResult
 
-matchLiterals (var:vars) ty sub_groups
+matchLiterals (var:vars) ty weight sub_groups
   = ASSERT( notNull sub_groups && all notNull sub_groups )
     do  {       -- Deal with each group
         ; alts <- mapM match_group sub_groups
@@ -366,7 +367,7 @@ matchLiterals (var:vars) ty sub_groups
     match_group eqns
         = do dflags <- getDynFlags
              let LitPat _ hs_lit = firstPat (head eqns)
-             match_result <- match vars ty (shiftEqns eqns)
+             match_result <- match vars ty weight (shiftEqns eqns)
              return (hsLitKey dflags hs_lit, match_result)
 
     wrap_str_guard :: Id -> (Literal,MatchResult) -> DsM MatchResult
@@ -380,7 +381,7 @@ matchLiterals (var:vars) ty sub_groups
              ; return (mkGuardedMatchResult pred mr) }
     wrap_str_guard _ (l, _) = pprPanic "matchLiterals/wrap_str_guard" (ppr l)
 
-matchLiterals [] _ _ = panic "matchLiterals []"
+matchLiterals [] _ _ _ = panic "matchLiterals []"
 
 ---------------------------
 hsLitKey :: DynFlags -> HsLit GhcTc -> Literal
@@ -411,17 +412,17 @@ hsLitKey _      l                  = pprPanic "hsLitKey" (ppr l)
 ************************************************************************
 -}
 
-matchNPats :: [Id] -> Type -> [EquationInfo] -> DsM MatchResult
-matchNPats (var:vars) ty (eqn1:eqns)    -- All for the same literal
+matchNPats :: [Id] -> Type -> Rig -> [EquationInfo] -> DsM MatchResult
+matchNPats (var:vars) ty weight (eqn1:eqns)    -- All for the same literal
   = do  { let NPat _ (L _ lit) mb_neg eq_chk = firstPat eqn1
         ; lit_expr <- dsOverLit lit
         ; neg_lit <- case mb_neg of
                             Nothing  -> return lit_expr
                             Just neg -> dsSyntaxExpr neg [lit_expr]
         ; pred_expr <- dsSyntaxExpr eq_chk [Var var, neg_lit]
-        ; match_result <- match vars ty (shiftEqns (eqn1:eqns))
+        ; match_result <- match vars ty weight (shiftEqns (eqn1:eqns))
         ; return (mkGuardedMatchResult pred_expr match_result) }
-matchNPats vars _ eqns = pprPanic "matchOneNPat" (ppr (vars, eqns))
+matchNPats vars _ _ eqns = pprPanic "matchOneNPat" (ppr (vars, eqns))
 
 {-
 ************************************************************************
@@ -441,16 +442,16 @@ We generate:
 \end{verbatim}
 -}
 
-matchNPlusKPats :: [Id] -> Type -> [EquationInfo] -> DsM MatchResult
+matchNPlusKPats :: [Id] -> Type -> Rig -> [EquationInfo] -> DsM MatchResult
 -- All NPlusKPats, for the *same* literal k
-matchNPlusKPats (var:vars) ty (eqn1:eqns)
+matchNPlusKPats (var:vars) ty weight (eqn1:eqns)
   = do  { let NPlusKPat _ (L _ n1) (L _ lit1) lit2 ge minus = firstPat eqn1
         ; lit1_expr   <- dsOverLit lit1
         ; lit2_expr   <- dsOverLit lit2
         ; pred_expr   <- dsSyntaxExpr ge    [Var var, lit1_expr]
         ; minusk_expr <- dsSyntaxExpr minus [Var var, lit2_expr]
         ; let (wraps, eqns') = mapAndUnzip (shift n1) (eqn1:eqns)
-        ; match_result <- match vars ty eqns'
+        ; match_result <- match vars ty weight eqns'
         ; return  (mkGuardedMatchResult pred_expr               $
                    mkCoLetMatchResult (NonRec n1 minusk_expr)   $
                    adjustMatchResult (foldr1 (.) wraps)         $
@@ -461,4 +462,4 @@ matchNPlusKPats (var:vars) ty (eqn1:eqns)
         -- The wrapBind is a no-op for the first equation
     shift _ e = pprPanic "matchNPlusKPats/shift" (ppr e)
 
-matchNPlusKPats vars _ eqns = pprPanic "matchNPlusKPats" (ppr (vars, eqns))
+matchNPlusKPats vars _ _ eqns = pprPanic "matchNPlusKPats" (ppr (vars, eqns))

--- a/compiler/hsSyn/HsBinds.hs
+++ b/compiler/hsSyn/HsBinds.hs
@@ -679,7 +679,7 @@ pprDeclList :: [SDoc] -> SDoc   -- Braces with a space
 pprDeclList ds = pprDeeperList vcat ds
 
 ------------
-emptyLocalBinds :: HsLocalBindsLR (GhcPass a) (GhcPass b)
+emptyLocalBinds :: (XEmptyLocalBinds a b ~ PlaceHolder) => HsLocalBindsLR a b
 emptyLocalBinds = EmptyLocalBinds noExt
 
 -- AZ:These functions do not seem to be used at all?

--- a/compiler/hsSyn/HsBinds.hs
+++ b/compiler/hsSyn/HsBinds.hs
@@ -679,7 +679,7 @@ pprDeclList :: [SDoc] -> SDoc   -- Braces with a space
 pprDeclList ds = pprDeeperList vcat ds
 
 ------------
-emptyLocalBinds :: (XEmptyLocalBinds a b ~ PlaceHolder) => HsLocalBindsLR a b
+emptyLocalBinds :: HsLocalBindsLR (GhcPass a) (GhcPass b)
 emptyLocalBinds = EmptyLocalBinds noExt
 
 -- AZ:These functions do not seem to be used at all?

--- a/compiler/hsSyn/HsExpr.hs
+++ b/compiler/hsSyn/HsExpr.hs
@@ -46,6 +46,7 @@ import Util
 import Outputable
 import FastString
 import Type
+import Weight
 
 -- libraries:
 import Data.Data hiding (Fixity(..))
@@ -1591,6 +1592,7 @@ data MatchGroup p body
   = MG { mg_alts    :: Located [LMatch p body]  -- The alternatives
        , mg_arg_tys :: [Weighted (PostTc p Type)]  -- Types of the arguments, t1..tn -- MattP: This looks wrong, should be PostTc ... (Weighted ..)
        , mg_res_ty  :: PostTc p Type    -- Type of the result, tr
+       , mg_weight :: PostTc p Rig -- The weight of the match
        , mg_origin  :: Origin }
      -- The type is the type of the entire group
      --      t1 -> ... -> tn -> tr

--- a/compiler/hsSyn/HsUtils.hs
+++ b/compiler/hsSyn/HsUtils.hs
@@ -144,10 +144,9 @@ just attach noSrcSpan to everything.
 mkHsPar :: LHsExpr (GhcPass id) -> LHsExpr (GhcPass id)
 mkHsPar e = L (getLoc e) (HsPar noExt e)
 
-mkSimpleMatch :: (XEmptyLocalBinds p p ~ PlaceHolder)
-               => HsMatchContext (NameOrRdrName (IdP p))
-              -> [LPat p] -> Located (body p)
-              -> LMatch p (Located (body p))
+mkSimpleMatch :: HsMatchContext (NameOrRdrName (IdP (GhcPass p)))
+              -> [LPat (GhcPass p)] -> Located (body (GhcPass p))
+              -> LMatch (GhcPass p) (Located (body (GhcPass p)))
 mkSimpleMatch ctxt pats rhs
   = L loc $
     Match { m_ctxt = ctxt, m_pats = pats
@@ -205,9 +204,8 @@ mkHsLams tyvars dicts expr = mkLHsWrap (mkWpTyLams tyvars
 
 -- |A simple case alternative with a single pattern, no binds, no guards;
 -- pre-typechecking
-mkHsCaseAlt :: (XEmptyLocalBinds p p ~ PlaceHolder)
-            => LPat p -> (Located (body p))
-            -> LMatch p (Located (body p))
+mkHsCaseAlt :: LPat (GhcPass p) -> (Located (body (GhcPass p)))
+            -> LMatch (GhcPass p) (Located (body (GhcPass p)))
 mkHsCaseAlt pat expr
   = mkSimpleMatch CaseAlt [pat] expr
 

--- a/compiler/hsSyn/HsUtils.hs
+++ b/compiler/hsSyn/HsUtils.hs
@@ -156,9 +156,8 @@ mkSimpleMatch ctxt pats rhs
                 []      -> getLoc rhs
                 (pat:_) -> combineSrcSpans (getLoc pat) (getLoc rhs)
 
-unguardedGRHSs :: (XEmptyLocalBinds p p ~ PlaceHolder)
-               => Located (body p)
-               -> GRHSs p (Located (body p))
+unguardedGRHSs :: Located (body (GhcPass p))
+               -> GRHSs (GhcPass p) (Located (body (GhcPass p)))
 unguardedGRHSs rhs@(L loc _)
   = GRHSs (unguardedRHS loc rhs) (noLoc emptyLocalBinds)
 

--- a/compiler/typecheck/TcArrows.hs
+++ b/compiler/typecheck/TcArrows.hs
@@ -259,7 +259,8 @@ tc_cmd env
                                          , m_grhss = grhss' })
               arg_tys = map hsLPatType pats'
               cmd' = HsCmdLam x (MG { mg_alts = L l [match'], mg_arg_tys = map unrestricted arg_tys
-                                  , mg_res_ty = res_ty, mg_origin = origin })
+                                  , mg_res_ty = res_ty, mg_origin = origin, mg_weight = Omega  })
+                                    -- MattP: Check
         ; return (mkHsCmdWrap (mkWpCastN co) cmd') }
   where
     n_pats     = length pats

--- a/compiler/typecheck/TcArrows.hs
+++ b/compiler/typecheck/TcArrows.hs
@@ -260,7 +260,10 @@ tc_cmd env
               arg_tys = map hsLPatType pats'
               cmd' = HsCmdLam x (MG { mg_alts = L l [match'], mg_arg_tys = map unrestricted arg_tys
                                   , mg_res_ty = res_ty, mg_origin = origin, mg_weight = Omega  })
-                                    -- MattP: Check
+                                    -- MattP: Check Omega here - not sure
+                                    -- what this was used for yet but
+                                    -- I think it's probably fine to be
+                                    -- Omega.
         ; return (mkHsCmdWrap (mkWpCastN co) cmd') }
   where
     n_pats     = length pats

--- a/compiler/typecheck/TcHsSyn.hs
+++ b/compiler/typecheck/TcHsSyn.hs
@@ -594,12 +594,14 @@ zonkMatchGroup :: ZonkEnv
             -> MatchGroup GhcTcId (Located (body GhcTcId))
             -> TcM (MatchGroup GhcTc (Located (body GhcTc)))
 zonkMatchGroup env zBody (MG { mg_alts = L l ms, mg_arg_tys = arg_tys
-                             , mg_res_ty = res_ty, mg_origin = origin })
+                             , mg_res_ty = res_ty, mg_origin = origin
+                             , mg_weight = w })
   = do  { ms' <- mapM (zonkMatch env zBody) ms
         ; Compose arg_tys' <- zonkTcTypeToTypes env (Compose arg_tys)
         ; res_ty'  <- zonkTcTypeToType env res_ty
         ; return (MG { mg_alts = L l ms', mg_arg_tys = arg_tys'
-                     , mg_res_ty = res_ty', mg_origin = origin }) }
+                     , mg_res_ty = res_ty', mg_origin = origin
+                     , mg_weight = w }) }
 
 zonkMatch :: ZonkEnv
           -> (ZonkEnv -> Located (body GhcTcId) -> TcM (Located (body GhcTc)))

--- a/compiler/typecheck/TcMatches.hs
+++ b/compiler/typecheck/TcMatches.hs
@@ -230,7 +230,8 @@ tcMatches ctxt pat_tys rhs_ty (MG { mg_alts = L l matches
        ; return (MG { mg_alts = L l matches'
                     , mg_arg_tys = pat_tys
                     , mg_res_ty = rhs_ty
-                    , mg_origin = origin }) }
+                    , mg_origin = origin
+                    , mg_weight = Omega }) } -- MattP: This information should be collected from above
 
 -------------
 tcMatch :: (Outputable (body GhcRn)) => TcMatchCtxt body

--- a/compiler/typecheck/TcPatSyn.hs
+++ b/compiler/typecheck/TcPatSyn.hs
@@ -678,6 +678,7 @@ tcPatSynMatcher (L loc name) lpat
                       , mg_arg_tys = [unrestricted pat_ty] -- TODO: arnaud: unrestricted is surely incorrect here
                       , mg_res_ty = res_ty
                       , mg_origin = Generated
+                      , mg_weight = Omega -- MattP: Probably wrong
                       }
              body' = noLoc $
                      HsLam noExt $
@@ -686,6 +687,7 @@ tcPatSynMatcher (L loc name) lpat
                        , mg_arg_tys = map unrestricted [pat_ty, cont_ty, fail_ty] -- TODO: arnaud: unrestricted is surely incorrect here
                        , mg_res_ty = res_ty
                        , mg_origin = Generated
+                       , mg_weight = Omega -- MattP: Probably wrong
                        }
              match = mkMatch (mkPrefixFunRhs (L loc name)) []
                              (mkHsLams (rr_tv:res_tv:univ_tvs)
@@ -696,6 +698,7 @@ tcPatSynMatcher (L loc name) lpat
                     , mg_arg_tys = []
                     , mg_res_ty = res_ty
                     , mg_origin = Generated
+                    , mg_weight = Omega -- MattP: Probably wrong
                     }
 
        ; let bind = FunBind{ fun_ext = emptyNameSet

--- a/ghc/GHCi/UI/Info.hs
+++ b/ghc/GHCi/UI/Info.hs
@@ -311,7 +311,7 @@ processAllTypeCheckedModule tcm = do
 
     -- | Extract 'Id', 'SrcSpan', and 'Type' for 'LHsBind's
     getTypeLHsBind :: LHsBind GhcTc -> m (Maybe (Maybe Id,SrcSpan,Type))
-    getTypeLHsBind (L _spn FunBind{fun_id = pid,fun_matches = MG _ _ _typ _})
+    getTypeLHsBind (L _spn FunBind{fun_id = pid,fun_matches = MG _ _ _typ _ _})
         = pure $ Just (Just (unLoc pid),getLoc pid,varType (unLoc pid))
     getTypeLHsBind _ = pure Nothing
 


### PR DESCRIPTION
When desugaring case expressions we sometimes invent new variables which
need to be scaled like source level case expressions. Storing this
weight allows us to perform this scaling appropiately.

This fixes test `T11339c` at least.