### PR TITLE
Core Lint: Check that a variables usage matches its weight

### DIFF
--- a/compiler/coreSyn/CoreLint.hs
+++ b/compiler/coreSyn/CoreLint.hs
@@ -1083,8 +1083,9 @@ lintAltBinders rhs_ue scrut_ty con_ty ((var_w, bndr):bndrs)
 
 -- | Implements the case rules for linearity
 checkCaseLinearity :: (Rig, Var -> Rig, Rig) ->  Rig -> Var -> LintM ()
-checkCaseLinearity (scrut_usage, var_usage, scrut_w) var_w bndr =
+checkCaseLinearity (scrut_usage, var_usage, scrut_w) var_w bndr = do
   lintL (lhs `subweight` rhs) err_msg
+  lintLinearBinder (ppr bndr) (scrut_w * var_w) (varWeight bndr)
   where
     lhs = var_usage bndr + (scrut_usage * var_w)
     rhs = scrut_w * var_w
@@ -1243,6 +1244,16 @@ lintCoreAlt lookup_scrut scrut_ty scrut_weight alt_ty alt@(DataAlt con, args, rh
 
   | otherwise   -- Scrut-ty is wrong shape
   = zeroUE <$ addErrL (mkBadAltMsg scrut_ty alt)
+
+lintLinearBinder :: SDoc -> Rig -> Rig -> LintM ()
+lintLinearBinder doc actual_usage described_usage
+  = lintL (actual_usage == described_usage)
+          err_msg
+    where
+      err_msg = (text "Weight of variable does agree with its context"
+                $$ doc
+                $$ ppr actual_usage
+                $$ text "Annotation:" <+> ppr described_usage)
 
 {-
 ************************************************************************


### PR DESCRIPTION
A variable bound in a pattern for a case_pi must have precisely weight
rho * pi where rho is the weight of the field.

This is already checked for let binders but was omitted here by
accident.
