### PR TITLE
Scale binders bound in a data con wrapper

### DIFF
--- a/compiler/basicTypes/Var.hs
+++ b/compiler/basicTypes/Var.hs
@@ -391,7 +391,8 @@ varWeightDef :: Id -> Rig
 varWeightDef = fromMaybe Omega . varWeightMaybe
 
 scaleVarBy :: Id -> Rig -> Id
-scaleVarBy id r = id { varWeight = r * (varWeight id) }
+scaleVarBy id r | isId id  = id { varWeight = r * (varWeight id) }
+scaleVarBy id _ = id
 
 {- *********************************************************************
 *                                                                      *

--- a/compiler/coreSyn/CoreLint.hs
+++ b/compiler/coreSyn/CoreLint.hs
@@ -1227,20 +1227,16 @@ lintCoreAlt lookup_scrut scrut_ty scrut_weight alt_ty alt@(DataAlt con, args, rh
         -- We've already check
       lintL (tycon == dataConTyCon con) (mkBadConMsg tycon con)
     ; let { con_payload_ty = piResultTys (dataConRepType con) tycon_arg_tys
-          ; (_, pred, con_args, _) = dataConSig con
-          ; ex_tvs = dataConExTyVars con
-          -- Weights of the things that the data con brings into scope
-          -- MattP: TODO: Move this into DataCon
-          ; weights = (replicate (length ex_tvs + length pred) Omega)
-                        ++ map weightedWeight (con_args) }
+          ; ex_tvs_n = length (dataConExTyVars con)
+          ; weights = replicate ex_tvs_n Omega ++
+                      map weightedWeight (dataConRepArgTys con) }
 
         -- And now bring the new binders into scope
     ; lintBinders CasePatBind args $ \ args' -> do
     {
     rhs_ue <- lintAltExpr rhs alt_ty ;
     let scrut_usage = lookup_scrut rhs_ue
-    -- This goes wrong, see GADT1 test, not sure if weight even matters
-    -- here
+--    ; pprTrace "lintCoreAlt" (ppr weights $$ ppr args' $$ ppr (dataConRepArgTys con) $$ ppr (dataConSig con)) ( return ())
     ; addLoc (CasePat alt) (lintAltBinders (scrut_usage, lookupUE rhs_ue, scrut_weight) scrut_ty con_payload_ty (zipEqual "lintCoreAlt" weights  args')) ;
     return rhs_ue
     } }

--- a/compiler/coreSyn/CoreLint.hs
+++ b/compiler/coreSyn/CoreLint.hs
@@ -1228,6 +1228,7 @@ lintCoreAlt lookup_scrut scrut_ty scrut_weight alt_ty alt@(DataAlt con, args, rh
       lintL (tycon == dataConTyCon con) (mkBadConMsg tycon con)
     ; let { con_payload_ty = piResultTys (dataConRepType con) tycon_arg_tys
           ; ex_tvs_n = length (dataConExTyVars con)
+          -- See Note [Alt arg weights]
           ; weights = replicate ex_tvs_n Omega ++
                       map weightedWeight (dataConRepArgTys con) }
 
@@ -1253,6 +1254,15 @@ lintLinearBinder doc actual_usage described_usage
                 $$ doc
                 $$ ppr actual_usage
                 $$ text "Annotation:" <+> ppr described_usage)
+
+{- Note [Alt arg weights]
+It is necessary to use `dataConRepArgTys` so you get the arg tys from
+the wrapper if there is one.
+
+For some reason, you also need to add the existential ty vars as they
+are passed are arguments but not returned by `dataConRepArgTys`. Without
+this the test `GADT1` fails.
+-}
 
 {-
 ************************************************************************

--- a/compiler/deSugar/DsUtils.hs
+++ b/compiler/deSugar/DsUtils.hs
@@ -399,7 +399,8 @@ mkDataConCase var ty alts@(alt1:_) = MatchResult fail_flag mk_case
                 Just (DCB boxer) ->
         do { us <- newUniqueSupply
            ; let (rep_ids, binds) = initUs_ us (boxer ty_args args)
-           ; return (DataAlt con, rep_ids, mkLets binds body) } } }
+           ; let rep_ids' = map (\i -> scaleIdBy i (idWeight var)) rep_ids
+           ; return (DataAlt con, rep_ids', mkLets binds body) } } }
 
     mk_default :: CoreExpr -> [CoreAlt]
     mk_default fail | exhaustive_case = []

--- a/testsuite/skip-tests.txt
+++ b/testsuite/skip-tests.txt
@@ -50,21 +50,6 @@ TcCoercible
 T13233
 T13244
 -- #82
--- Iface lint
-T11232
-T3245
-T4003
-T5129
-T7649
-T7918
-T7924
-T9583
-dynamic004
-spec-inline
-simplrun010
-### Core Lint - Zip Equal
-T12757
-
 
 # 78
 T12944

--- a/testsuite/skip-tests.txt
+++ b/testsuite/skip-tests.txt
@@ -62,26 +62,6 @@ T9583
 dynamic004
 spec-inline
 simplrun010
-### Desugaring - Looks like something to do with unlifted types
-T12622
-T12689a
-T13750
-T14290
-T14650
-T3736
-T3972
-T5603
-T5453
-T8221
-T8425
-bkprun09
-cg005
-determ008
-hClose002
-hClose003
-hDuplicateTo001
-spec001
-T4306
 ### Core Lint - Zip Equal
 T12757
 


### PR DESCRIPTION
There are three changes in these three commits which each fix a problem.

1. In `DsUtils` we have to scale the binders by the weight of the case. (See #82 for the tests this fixes)
2. `scaleVarBy` was needlessly partial, we so we fix that by performing a no-op in the case we don't have an `Id`
3. My complicated calculations in `lintCoreAlt` turned out to be wrong - surprise, surprise. We need to use `dataConRepArgTys` to properly account for data con wrappers but for some reason still deal explicitly with existentially bound variables.