### PR TITLE
Skip two tests failing only on CI

### DIFF
--- a/testsuite/skip-tests.txt
+++ b/testsuite/skip-tests.txt
@@ -1,3 +1,6 @@
+-- CI Failures but not locally #85
+sc002
+T3001-2
 -- ETA-expansion tests
 cgrun075
 cgrun076


### PR DESCRIPTION
Tracked by #85

I think these will be fixed by other fixes in due course.