### PR TITLE
Binder multiplicities in desugarer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,8 +100,6 @@ jobs:
       - *boot
       - *configure_unix
       - *make
-      - *bindist
-      - *storeartifacts
       - *test
       - *store_test_results
 

--- a/compiler/deSugar/DsExpr.hs
+++ b/compiler/deSugar/DsExpr.hs
@@ -217,7 +217,7 @@ dsUnliftedBind (PatBind {pat_lhs = pat, pat_rhs = grhss
              eqn = EqnInfo { eqn_pats = [upat],
                              eqn_rhs = cantFailMatchResult body }
        ; var    <- selectMatchVar Omega upat -- TODO: MattP
-       ; result <- matchEquations PatBindRhs [var] [eqn] (exprType body) Omega -- MattP: TODO check this multiplicity.
+       ; result <- matchEquations PatBindRhs [var] [eqn] (exprType body)
        ; return (bindNonRec var rhs result) }
 
 dsUnliftedBind bind body = pprPanic "dsLet: unlifted" (ppr bind $$ ppr body)

--- a/compiler/deSugar/DsExpr.hs
+++ b/compiler/deSugar/DsExpr.hs
@@ -672,11 +672,14 @@ ds_expr _ expr@(RecordUpd { rupd_expr = record_expr, rupd_flds = fields
       = do { let (univ_tvs, ex_tvs, eq_spec,
                   prov_theta, _req_theta, arg_tys, _) = conLikeFullSig con
                  subst = zipTvSubst univ_tvs in_inst_tys
+                 arg_tys' = scaleWeighted Omega <$> arg_tys
+                   -- Record updates consume the source record with multiplicity
+                   -- Omega. Therefore all the fields need to be scaled thus.
 
                 -- I'm not bothering to clone the ex_tvs
            ; eqs_vars   <- mapM newPredVarDs (substTheta subst (eqSpecPreds eq_spec))
            ; theta_vars <- mapM newPredVarDs (substTheta subst prov_theta)
-           ; arg_ids    <- newSysLocalsDs (getCompose $ substTysUnchecked subst (Compose arg_tys))
+           ; arg_ids    <- newSysLocalsDs (getCompose $ substTysUnchecked subst (Compose arg_tys'))
            ; let field_labels = conLikeFieldLabels con
                  val_args = zipWithEqual "dsExpr:RecordUpd" mk_val_arg
                                          field_labels arg_ids

--- a/compiler/deSugar/Match.hs
+++ b/compiler/deSugar/Match.hs
@@ -715,9 +715,8 @@ matchWrapper ctxt mb_scr (MG { mg_alts = L _ matches
                              , mg_origin = origin })
   = do  { dflags <- getDynFlags
         ; locn   <- getSrcSpanDs
-        ; let scale_new_vars = map (\var -> scaleIdBy var weight)
 
-        ; new_vars    <- scale_new_vars <$> case matches of
+        ; new_vars    <- case matches of
                            []    -> mapM (\(Weighted w ty) -> newSysLocalDsNoLP w ty) arg_tys
                            (m:_) ->
                             selectMatchVars (zipWithEqual "matchWrapper"

--- a/compiler/deSugar/Match.hs
+++ b/compiler/deSugar/Match.hs
@@ -160,12 +160,15 @@ type MatchId = Id   -- See Note [Match Ids]
 
 match :: [MatchId]        -- Variables rep\'ing the exprs we\'re matching with
                           -- See Note [Match Ids]
+                          --
+                          -- Note that the Match Ids carry not only a name, but
+                          -- also the multiplicity at which each column has been
+                          -- type checked.
       -> Type             -- Type of the case expression
-      -> Rig              -- multiplicity of the case expression
       -> [EquationInfo]   -- Info about patterns, etc. (type synonym below)
       -> DsM MatchResult  -- Desugared result!
 
-match [] ty _w eqns
+match [] ty eqns
   = ASSERT2( not (null eqns), ppr ty )
     return (foldr1 combineMatchResults match_results)
   where
@@ -173,7 +176,7 @@ match [] ty _w eqns
                       eqn_rhs eqn
                     | eqn <- eqns ]
 
-match vars@(v:_) ty weight eqns    -- Eqns *can* be empty
+match vars@(v:_) ty eqns    -- Eqns *can* be empty
   = ASSERT2( all (isInternalName . idName) vars, ppr vars )
     do  { dflags <- getDynFlags
                 -- Tidy the first pattern, generating
@@ -195,7 +198,7 @@ match vars@(v:_) ty weight eqns    -- Eqns *can* be empty
 
     match_groups :: [[(PatGroup,EquationInfo)]] -> DsM [MatchResult]
     -- Result list of [MatchResult] is always non-empty
-    match_groups [] = matchEmpty v ty weight
+    match_groups [] = matchEmpty v ty
     match_groups gs = mapM match_group gs
 
     match_group :: [(PatGroup,EquationInfo)] -> DsM MatchResult
@@ -203,17 +206,17 @@ match vars@(v:_) ty weight eqns    -- Eqns *can* be empty
     match_group eqns@((group,_) : _)
         =
           case group of
-            PgCon {}  -> matchConFamily  vars ty weight (subGroupUniq [(c,e) | (PgCon c, e) <- eqns])
-            PgSyn {}  -> matchPatSyn     vars ty weight (dropGroup eqns)
-            PgLit {}  -> matchLiterals   vars ty weight (subGroupOrd [(l,e) | (PgLit l, e) <- eqns])
-            PgAny     -> matchVariables  vars ty weight (dropGroup eqns)
-            PgN {}    -> matchNPats      vars ty weight (dropGroup eqns)
-            PgOverS {}-> matchNPats      vars ty weight (dropGroup eqns)
-            PgNpK {}  -> matchNPlusKPats vars ty weight (dropGroup eqns)
-            PgBang    -> matchBangs      vars ty weight (dropGroup eqns)
-            PgCo {}   -> matchCoercion   vars ty weight (dropGroup eqns)
-            PgView {} -> matchView       vars ty weight (dropGroup eqns)
-            PgOverloadedList -> matchOverloadedList vars ty weight (dropGroup eqns)
+            PgCon {}  -> matchConFamily  vars ty (subGroupUniq [(c,e) | (PgCon c, e) <- eqns])
+            PgSyn {}  -> matchPatSyn     vars ty (dropGroup eqns)
+            PgLit {}  -> matchLiterals   vars ty (subGroupOrd [(l,e) | (PgLit l, e) <- eqns])
+            PgAny     -> matchVariables  vars ty (dropGroup eqns)
+            PgN {}    -> matchNPats      vars ty (dropGroup eqns)
+            PgOverS {}-> matchNPats      vars ty (dropGroup eqns)
+            PgNpK {}  -> matchNPlusKPats vars ty (dropGroup eqns)
+            PgBang    -> matchBangs      vars ty (dropGroup eqns)
+            PgCo {}   -> matchCoercion   vars ty (dropGroup eqns)
+            PgView {} -> matchView       vars ty (dropGroup eqns)
+            PgOverloadedList -> matchOverloadedList vars ty (dropGroup eqns)
 
     -- FIXME: we should also warn about view patterns that should be
     -- commoned up but are not
@@ -230,43 +233,43 @@ match vars@(v:_) ty weight eqns    -- Eqns *can* be empty
           maybeWarn $ (map (\g -> text "Putting these view expressions into the same case:" <+> (ppr g))
                        (filter (not . null) gs))
 
-matchEmpty :: HasCallStack => MatchId -> Type -> Rig -> DsM [MatchResult]
+matchEmpty :: HasCallStack => MatchId -> Type -> DsM [MatchResult]
 -- See Note [Empty case expressions]
-matchEmpty var res_ty _weight
+matchEmpty var res_ty
   = return [MatchResult CanFail mk_seq]
   where
     mk_seq fail = return $ mkWildCase (Var var) (Weighted (idWeight var) (idType var)) res_ty
                                       [(DEFAULT, [], fail)]
 
-matchVariables :: [MatchId] -> Type -> Rig -> [EquationInfo] -> DsM MatchResult
+matchVariables :: [MatchId] -> Type -> [EquationInfo] -> DsM MatchResult
 -- Real true variables, just like in matchVar, SLPJ p 94
 -- No binding to do: they'll all be wildcards by now (done in tidy)
-matchVariables (_:vars) ty weight eqns = match vars ty weight(shiftEqns eqns)
-matchVariables [] _ _ _ = panic "matchVariables"
+matchVariables (_:vars) ty eqns = match vars ty (shiftEqns eqns)
+matchVariables [] _ _ = panic "matchVariables"
 
-matchBangs :: [MatchId] -> Type -> Rig -> [EquationInfo] -> DsM MatchResult
-matchBangs (var:vars) ty weight eqns
-  = do  { match_result <- match (var:vars) ty weight $
+matchBangs :: [MatchId] -> Type -> [EquationInfo] -> DsM MatchResult
+matchBangs (var:vars) ty eqns
+  = do  { match_result <- match (var:vars) ty $
                           map (decomposeFirstPat getBangPat) eqns
         ; return (mkEvalMatchResult var ty match_result) }
-matchBangs [] _ _ _ = panic "matchBangs"
+matchBangs [] _ _ = panic "matchBangs"
 
-matchCoercion :: HasCallStack => [MatchId] -> Type -> Rig -> [EquationInfo] -> DsM MatchResult
+matchCoercion :: HasCallStack => [MatchId] -> Type -> [EquationInfo] -> DsM MatchResult
 -- Apply the coercion to the match variable and then match that
-matchCoercion (var:vars) ty weight (eqns@(eqn1:_))
+matchCoercion (var:vars) ty (eqns@(eqn1:_))
   = do  { let CoPat _ co pat _ = firstPat eqn1
         ; let pat_ty' = hsPatType pat
         ; var' <- newUniqueId var (idWeight var) pat_ty'
-        ; match_result <- match (var':vars) ty weight $
+        ; match_result <- match (var':vars) ty $
                           map (decomposeFirstPat getCoPat) eqns
         ; core_wrap <- dsHsWrapper co
         ; let bind = NonRec var' (core_wrap (Var var))
         ; return (mkCoLetMatchResult bind match_result) }
-matchCoercion _ _ _ _ = panic "matchCoercion"
+matchCoercion _ _ _ = panic "matchCoercion"
 
-matchView :: HasCallStack => [MatchId] -> Type -> Rig -> [EquationInfo] -> DsM MatchResult
+matchView :: HasCallStack => [MatchId] -> Type -> [EquationInfo] -> DsM MatchResult
 -- Apply the view function to the match variable and then match that
-matchView (var:vars) ty weight (eqns@(eqn1:_))
+matchView (var:vars) ty (eqns@(eqn1:_))
   = do  { -- we could pass in the expr from the PgView,
          -- but this needs to extract the pat anyway
          -- to figure out the type of the fresh variable
@@ -274,26 +277,26 @@ matchView (var:vars) ty weight (eqns@(eqn1:_))
          -- do the rest of the compilation
         ; let pat_ty' = hsPatType pat
         ; var' <- newUniqueId var (idWeight var) pat_ty' -- MattP: I am fairly sure this is right now -- or at least -- not very wrong
-        ; match_result <- match (var':vars) ty weight $
+        ; match_result <- match (var':vars) ty $
                           map (decomposeFirstPat getViewPat) eqns
          -- compile the view expressions
         ; viewExpr' <- dsLExpr viewExpr
         ; return (mkViewMatchResult var'
                     (mkCoreAppDs (text "matchView") viewExpr' (Var var))
                     match_result) }
-matchView _ _ _ _ = panic "matchView"
+matchView _ _ _ = panic "matchView"
 
-matchOverloadedList :: HasCallStack => [MatchId] -> Type -> Rig -> [EquationInfo] -> DsM MatchResult
-matchOverloadedList (var:vars) ty weight (eqns@(eqn1:_))
+matchOverloadedList :: HasCallStack => [MatchId] -> Type -> [EquationInfo] -> DsM MatchResult
+matchOverloadedList (var:vars) ty (eqns@(eqn1:_))
 -- Since overloaded list patterns are treated as view patterns,
 -- the code is roughly the same as for matchView
   = do { let ListPat (ListPatTc elt_ty (Just (_,e))) _ = firstPat eqn1
        ; var' <- newUniqueId var (idWeight var) (mkListTy elt_ty)  -- we construct the overall type by hand
-       ; match_result <- match (var':vars) ty weight $
+       ; match_result <- match (var':vars) ty $
                             map (decomposeFirstPat getOLPat) eqns -- getOLPat builds the pattern inside as a non-overloaded version of the overloaded list pattern
        ; e' <- dsSyntaxExpr e [Var var]
        ; return (mkViewMatchResult var' e' match_result) }
-matchOverloadedList _ _ _ _ = panic "matchOverloadedList"
+matchOverloadedList _ _ _ = panic "matchOverloadedList"
 
 -- decompose the first pattern and leave the rest alone
 decomposeFirstPat :: (Pat GhcTc -> Pat GhcTc) -> EquationInfo -> EquationInfo
@@ -734,7 +737,7 @@ matchWrapper ctxt mb_scr (MG { mg_alts = L _ matches
           checkMatches dflags (DsMatchContext ctxt locn) new_vars matches
 
         ; result_expr <- handleWarnings $
-                         matchEquations ctxt new_vars eqns_info rhs_ty weight
+                         matchEquations ctxt new_vars eqns_info rhs_ty
         ; return (new_vars, result_expr) }
   where
     mk_eqn_info vars (L _ (Match { m_pats = pats, m_grhss = grhss }))
@@ -754,12 +757,12 @@ matchWrapper ctxt mb_scr (MG { mg_alts = L _ matches
 matchWrapper _ _ (XMatchGroup _) = panic "matchWrapper"
 
 matchEquations  :: HsMatchContext Name
-                -> [MatchId] -> [EquationInfo] -> Type -> Rig
+                -> [MatchId] -> [EquationInfo] -> Type
                 -> DsM CoreExpr
-matchEquations ctxt vars eqns_info rhs_ty weight
+matchEquations ctxt vars eqns_info rhs_ty
   = do  { let error_doc = matchContextErrString ctxt
 
-        ; match_result <- match vars rhs_ty weight eqns_info
+        ; match_result <- match vars rhs_ty eqns_info
 
         ; fail_expr <- mkErrorAppDs pAT_ERROR_ID rhs_ty error_doc
         ; extractMatchResult match_result fail_expr }
@@ -822,7 +825,7 @@ match_single_pat_var var ctx pat ty match_result
 
        ; let eqn_info = EqnInfo { eqn_pats = [unLoc (decideBangHood dflags pat)]
                                 , eqn_rhs  = match_result }
-       ; match [var] ty Omega [eqn_info] } -- MattP: TODO Not sure what this is used for
+       ; match [var] ty [eqn_info] }
 
 
 {-

--- a/compiler/deSugar/Match.hs-boot
+++ b/compiler/deSugar/Match.hs-boot
@@ -12,7 +12,6 @@ import Weight   ( Rig )
 
 match   :: [Id]
         -> Type
-        -> Rig
         -> [EquationInfo]
         -> DsM MatchResult
 

--- a/compiler/hsSyn/HsExpr.hs
+++ b/compiler/hsSyn/HsExpr.hs
@@ -1633,6 +1633,13 @@ data MatchGroupTc
        { mg_arg_tys :: [Weighted Type]  -- Types of the arguments, t1..tn
        , mg_res_ty  :: Type    -- Type of the result, tr
        , mg_weight  :: Rig     -- Weight of the result
+                               --
+                               -- TODO: arnaud: I'm deeply suspicious of this
+                               -- mg_weight. If only because, really, there is
+                               -- no one multiplicity for the match; rather
+                               -- there is one per column. And this is embodied
+                               -- by the multiplicities in mg_arg_tys. So
+                               -- probably remove on clean up.
        } deriving Data
 
 type instance XMG         GhcPs b = NoExt

--- a/compiler/typecheck/TcBinds.hs
+++ b/compiler/typecheck/TcBinds.hs
@@ -1360,7 +1360,7 @@ tcMonoBinds is_rec sig_fn no_gen
                   -- type of the thing whose rhs we are type checking
                tcMatchesFun (L nm_loc name) matches exp_ty
 
-        ; mono_id <- newLetBndr no_gen name rhs_ty
+        ; mono_id <- newLetBndr no_gen name Omega rhs_ty -- TODO: arnaud: I don't know what binders we are creating here, so I don't know yet where the multiplicity is supposed to come from
         ; return (unitBag $ L b_loc $
                      FunBind { fun_id = L nm_loc mono_id,
                                fun_matches = matches', fun_ext = fvs,
@@ -1435,7 +1435,7 @@ tcLhs sig_fn no_gen (FunBind { fun_id = L nm_loc name, fun_matches = matches })
 
   | otherwise  -- No type signature
   = do { mono_ty <- newOpenFlexiTyVarTy
-       ; mono_id <- newLetBndr no_gen name mono_ty
+       ; mono_id <- newLetBndr no_gen name Omega mono_ty -- TODO: arnaud: I don't know what binder we are creating here, so I don't know where the multiplicity should come from
        ; let mono_info = MBI { mbi_poly_name = name
                              , mbi_sig       = Nothing
                              , mbi_mono_id   = mono_id }
@@ -1503,7 +1503,7 @@ newSigLetBndr (LetGblBndr prags) name (TISI { sig_inst_sig = id_sig })
   | CompleteSig { sig_bndr = poly_id } <- id_sig
   = addInlinePrags poly_id (lookupPragEnv prags name)
 newSigLetBndr no_gen name (TISI { sig_inst_tau = tau })
-  = newLetBndr no_gen name tau
+  = newLetBndr no_gen name Omega tau -- TODO: arnaud: I don't know what binder we are creating here, so I don't know where the multiplicity should come from
 
 -------------------
 tcRhs :: TcMonoBind -> TcM (HsBind GhcTcId)

--- a/compiler/typecheck/TcMatches.hs
+++ b/compiler/typecheck/TcMatches.hs
@@ -212,7 +212,6 @@ data TcMatchCtxt body   -- c.f. TcStmtCtxt, also in this module
                                                 -- an alternative
                  -> ExpRhoType
                  -> TcM (Located (body GhcTcId)) }
-
 tcMatches ctxt pat_tys rhs_ty (MG { mg_alts = L l matches
                                   , mg_origin = origin })
   = do { (Weighted _ rhs_ty):pat_tys <- tauifyMultipleMatches matches ((Weighted One rhs_ty):pat_tys) -- return type has implicitly weight 1, it doesn't matter all that much in this case since it isn't used and is eliminated immediately.


### PR DESCRIPTION
The binders were over-eagerly scaled. Generally by Omega. This PR fetches the multiplicities closer to the binders (for when new variables need to be created by the desugarer). It also avoids scaling variables whose multiplicity is already known (which would change a variable of multiplicity `p` (a variable) into `p * p` which is problematic).

This is overall a simplification, I think. In that it reduces the number of changed lines in the overall diff.

I tucked something about Circle CI. Because it felt too trivial to put in another PR.