### PR TITLE
Linter: fix usage of case alternatives

### DIFF
--- a/compiler/coreSyn/CoreLint.hs
+++ b/compiler/coreSyn/CoreLint.hs
@@ -842,7 +842,7 @@ lintCoreExpr e@(Case scrut var alt_ty alts) =
      ; lintIdBndr NotTopLevel CaseBind var $ \_ ->
        do { -- Check the alternatives
           ; alt_ues <- mapM (lintCoreAlt (\e -> lookupUE e var) scrut_ty scrut_weight alt_ty) alts
-          ; let case_ue = (scaleUE scrut_weight scrut_ue) `addUE` addUEs alt_ues
+          ; let case_ue = (scaleUE scrut_weight scrut_ue) `addUE` supUEs alt_ues
           ; checkCaseAlts e scrut_ty alts
           ; return (alt_ty, case_ue) } }
 

--- a/compiler/types/UsageEnv.hs
+++ b/compiler/types/UsageEnv.hs
@@ -45,9 +45,6 @@ addUE :: UsageEnv -> UsageEnv -> UsageEnv
 addUE (UsageEnv e1) (UsageEnv e2) = UsageEnv $
   plusNameEnv_C (+) e1 e2
 
-addUEs :: [UsageEnv] -> UsageEnv
-addUEs = foldr addUE emptyUE
-
 scaleUE :: Rig -> UsageEnv -> UsageEnv
 scaleUE w (UsageEnv e) = UsageEnv $
   mapNameEnv (w*) e
@@ -55,6 +52,14 @@ scaleUE w (UsageEnv e) = UsageEnv $
 supUE :: UsageEnv -> UsageEnv -> UsageEnv
 supUE (UsageEnv e1) (UsageEnv e2) = UsageEnv $
   plusNameEnv_CD sup e1 Zero e2 Zero
+
+supUEs :: [UsageEnv] -> UsageEnv
+supUEs [] = zeroUE -- TODO: arnaud: this is incorrect, it should be the bottom
+                   -- usage env, but I haven't defined it yet. Then we could use
+                   -- a foldr and wouldn't need to special-case the empty list
+                   -- as currently. This hack/error is duplicated somewhere else
+                   -- too.
+supUEs l = foldr1 supUE l
 
 -- TODO: arnaud: both delete function: unify argument order with existing similar functions.
 -- | @deleteUEAsserting w x env@ deletes the binding to @x@ in @env@ under one


### PR DESCRIPTION
Was mistakenly summing the usage of alternatives, reverted to joining,
as it ought to