### PR TITLE
Do-notation: propagate pattern-multiplicity to the renamer

### DIFF
--- a/compiler/deSugar/DsArrows.hs
+++ b/compiler/deSugar/DsArrows.hs
@@ -322,7 +322,7 @@ dsProcExpr pat (L _ (HsCmdTop (CmdTopTc _unitTy cmd_ty ids) cmd)) = do
     let env_stk_ty = mkCorePairTy env_ty unitTy
     let env_stk_expr = mkCorePairExpr (mkBigCoreVarTup env_ids) mkCoreUnitExpr
     fail_expr <- mkFailExpr ProcExpr env_stk_ty
-    var <- selectSimpleMatchVarL pat
+    var <- selectSimpleMatchVarL Omega pat -- TODO: arnaud: handle arrows properly
     match_code <- matchSimply (Var var) ProcExpr pat env_stk_expr fail_expr
     let pat_ty = hsLPatType pat
     let proc_code = do_premap meth_ids pat_ty env_stk_ty cmd_ty
@@ -878,7 +878,7 @@ dsCmdStmt ids local_vars out_ids (BindStmt _ pat cmd _ _) env_ids = do
         body_expr = coreCaseTuple uniqs env_id env_ids2 (mkBigCoreVarTup out_ids)
 
     fail_expr <- mkFailExpr (StmtCtxt DoExpr) out_ty
-    pat_id    <- selectSimpleMatchVarL pat
+    pat_id    <- selectSimpleMatchVarL Omega pat -- TODO: arnaud: handle arrows correctly
     match_code <- matchSimply (Var pat_id) (StmtCtxt DoExpr) pat body_expr fail_expr
     pair_id   <- newSysLocalDs Omega after_c_ty -- TODO: arnaud: handle arrows correctly
     let

--- a/compiler/deSugar/DsExpr.hs
+++ b/compiler/deSugar/DsExpr.hs
@@ -939,10 +939,10 @@ dsDo stmts
       = do { rest <- goL stmts
            ; dsLocalBinds binds rest }
 
-    go _ (BindStmt res1_ty pat rhs bind_op fail_op) stmts
+    go _ (BindStmt (pat_weight, res1_ty) pat rhs bind_op fail_op) stmts
       = do  { body     <- goL stmts
             ; rhs'     <- dsLExpr rhs
-            ; var   <- selectSimpleMatchVarL pat
+            ; var   <- selectSimpleMatchVarL pat_weight pat
             ; match <- matchSinglePat (Var var) (StmtCtxt DoExpr) pat
                                       res1_ty (cantFailMatchResult body)
             ; match_code <- handle_failure pat match fail_op
@@ -988,7 +988,7 @@ dsDo stmts
                         , recS_ret_ty = body_ty} }) stmts
       = goL (new_bind_stmt : stmts)  -- rec_ids can be empty; eg  rec { print 'x' }
       where
-        new_bind_stmt = L loc $ BindStmt bind_ty (mkBigLHsPatTupId later_pats)
+        new_bind_stmt = L loc $ BindStmt (Omega, bind_ty) (mkBigLHsPatTupId later_pats) -- TODO: arnaud: I'm not sure what is being desugared here.
                                          mfix_app bind_op
                                          noSyntaxExpr  -- Tuple cannot fail
 

--- a/compiler/deSugar/DsListComp.hs
+++ b/compiler/deSugar/DsListComp.hs
@@ -709,7 +709,8 @@ dsMcStmt (LetStmt _ binds) stmts
        ; dsLocalBinds binds rest }
 
 --   [ .. | a <- m, stmts ]
-dsMcStmt (BindStmt bind_ty pat rhs bind_op fail_op) stmts
+dsMcStmt (BindStmt (_w, bind_ty) pat rhs bind_op fail_op) stmts
+  -- TODO: arnaud: we're losing a multiplicity here
   = do { rhs' <- dsLExpr rhs
        ; dsMcBindStmt pat rhs' bind_op fail_op bind_ty stmts }
 
@@ -829,7 +830,7 @@ dsMcBindStmt :: LPat GhcTc
              -> DsM CoreExpr
 dsMcBindStmt pat rhs' bind_op fail_op res1_ty stmts
   = do  { body     <- dsMcStmts stmts
-        ; var      <- selectSimpleMatchVarL pat
+        ; var      <- selectSimpleMatchVarL Omega pat -- TODO: arnaud: the correct pat_weight is somewhere in the caller, but I'll fix later, when list comprehension have test cases.
         ; match <- matchSinglePat (Var var) (StmtCtxt DoExpr) pat
                                   res1_ty (cantFailMatchResult body)
         ; match_code <- handle_failure pat match fail_op

--- a/compiler/deSugar/DsUtils.hs
+++ b/compiler/deSugar/DsUtils.hs
@@ -97,8 +97,8 @@ hand, which should indeed be bound to the pattern as a whole, then use it;
 otherwise, make one up.
 -}
 
-selectSimpleMatchVarL :: LPat GhcTc -> DsM Id
-selectSimpleMatchVarL pat = selectMatchVar Omega (unLoc pat)
+selectSimpleMatchVarL :: Rig -> LPat GhcTc -> DsM Id
+selectSimpleMatchVarL w pat = selectMatchVar w (unLoc pat)
 -- TODO: MattP: This function is used in a few places where is might be
 -- necessary to take into account multiplicity but it wasn't on the
 -- critical path to fix for now.
@@ -129,6 +129,12 @@ selectMatchVar w (LazyPat _ pat) = selectMatchVar w (unLoc pat)
 selectMatchVar w (ParPat _ pat)  = selectMatchVar w (unLoc pat)
 selectMatchVar _w (VarPat _ var)  = return (localiseId (unLoc var))
                                   -- Note [Localise pattern binders]
+                                  --
+                                  -- Remark: when the pattern is a variable (or
+                                  -- an @-pattern), then w is the same as the
+                                  -- multiplicity stored within the variable
+                                  -- itself. It's easier to pull it from the
+                                  -- variable, so we ignore the weight.
 selectMatchVar _w (AsPat _ var _) = return (unLoc var)
 selectMatchVar w other_pat     = newSysLocalDsNoLP w (hsPatType other_pat)
 

--- a/compiler/deSugar/Match.hs
+++ b/compiler/deSugar/Match.hs
@@ -808,7 +808,7 @@ matchSinglePat (Var var) ctx pat ty match_result
   = match_single_pat_var var ctx pat ty match_result
 
 matchSinglePat scrut hs_ctx pat ty match_result
-  = do { var           <- selectSimpleMatchVarL pat
+  = do { var           <- selectSimpleMatchVarL Omega pat -- TODO: arnaud: I don't know where it's used. But I'd be surprised it if were not a bug.
        ; match_result' <- match_single_pat_var var hs_ctx pat ty match_result
        ; return (adjustMatchResult (bindNonRec var scrut) match_result') }
 

--- a/compiler/hsSyn/HsExpr.hs
+++ b/compiler/hsSyn/HsExpr.hs
@@ -1921,9 +1921,10 @@ data StmtLR idL idR body -- body should always be (LHs**** idR)
                              -- 'ApiAnnotation.AnnLarrow'
 
   -- For details on above see note [Api annotations] in ApiAnnotation
-  | BindStmt (XBindStmt idL idR body) -- Post typechecking,
-                                -- result type of the function passed to bind;
-                                -- that is, S in (>>=) :: Q -> (R -> S) -> T
+  | BindStmt (XBindStmt idL idR body) -- Post typechecking, multiplicity of the
+                                -- argument and result type of the function
+                                -- passed to bind; that is, (P, S) in
+                                -- (>>=) :: Q :_-> (R :P-> S) :_-> T
              (LPat idL)
              body
              (SyntaxExpr idR) -- The (>>=) operator; see Note [The type of bind in Stmts]
@@ -2043,7 +2044,7 @@ type instance XLastStmt        (GhcPass _) (GhcPass _) b = NoExt
 
 type instance XBindStmt        (GhcPass _) GhcPs b = NoExt
 type instance XBindStmt        (GhcPass _) GhcRn b = NoExt
-type instance XBindStmt        (GhcPass _) GhcTc b = Type
+type instance XBindStmt        (GhcPass _) GhcTc b = (Rig, Type)
 
 type instance XApplicativeStmt (GhcPass _) GhcPs b = NoExt
 type instance XApplicativeStmt (GhcPass _) GhcRn b = NoExt

--- a/compiler/hsSyn/HsUtils.hs
+++ b/compiler/hsSyn/HsUtils.hs
@@ -304,7 +304,7 @@ mkBodyStmt body
   = BodyStmt noExt body noSyntaxExpr noSyntaxExpr
 mkBindStmt pat body
   = BindStmt noExt pat body noSyntaxExpr noSyntaxExpr
-mkTcBindStmt pat body = BindStmt unitTy pat body noSyntaxExpr noSyntaxExpr
+mkTcBindStmt pat body = BindStmt (Omega, unitTy) pat body noSyntaxExpr noSyntaxExpr
   -- don't use placeHolderTypeTc above, because that panics during zonking
 
 emptyRecStmt' :: forall idL idR body.

--- a/compiler/typecheck/TcHsSyn.hs
+++ b/compiler/typecheck/TcHsSyn.hs
@@ -1142,14 +1142,15 @@ zonkStmt env _ (LetStmt x (L l binds))
   = do (env1, new_binds) <- zonkLocalBinds env binds
        return (env1, LetStmt x (L l new_binds))
 
-zonkStmt env zBody (BindStmt bind_ty pat body bind_op fail_op)
+zonkStmt env zBody (BindStmt (w, bind_ty) pat body bind_op fail_op)
   = do  { (env1, new_bind) <- zonkSyntaxExpr env bind_op
+        ; new_w <- zonkRig env1 w
         ; new_bind_ty <- zonkTcTypeToType env1 bind_ty
         ; new_body <- zBody env1 body
         ; (env2, new_pat) <- zonkPat env1 pat
         ; (_, new_fail) <- zonkSyntaxExpr env1 fail_op
         ; return ( env2
-                 , BindStmt new_bind_ty new_pat new_body new_bind new_fail) }
+                 , BindStmt (new_w, new_bind_ty) new_pat new_body new_bind new_fail) }
 
 -- Scopes: join > ops (in reverse order) > pats (in forward order)
 --              > rest of stmts


### PR DESCRIPTION
In

```haskell
do
  pat <- rhs
  body
```

If `pat` is not a variable, then the multiplicity was lost (that is,
for `(>>=) :: a :p-> (b :q-> c) :r-> d`, the renamed needs `q`) and it
would always be desugared to

```haskell
rhs >>= (\ x ::[ω] -> case x of pat -> body)
```

Which is ill-typed.