### PR TITLE
Fix coercions of arrow types

### DIFF
--- a/compiler/basicTypes/DataCon.hs
+++ b/compiler/basicTypes/DataCon.hs
@@ -586,6 +586,7 @@ data DataConRep
 -- (We could match on the wrappers,
 -- but that makes it less likely that rules will match
 -- when we bring bits of unfoldings together.)
+-- TODO: arnaud: revise this comment in view of the new wrapper policy
 
 -------------------------
 
@@ -928,18 +929,18 @@ mkDataCon name declared_infix prom_info
     rep_arg_tys = dataConRepArgTys con
 
     rep_ty =
+      -- TODO: arnaud: if we stay on the mode that all data constructors have
+      -- wrappers, then we need to remove this test.
       case rep of
         -- If the DataCon has no wrapper, then the worker's type *is* the
-        -- user-facing type, so we can simply use dataConUserType.
-        -- See Note [All data constructors have wrappers]
+        -- user-facing type, so we can simply use dataConUserType
 --        NoDataConRep -> dataConUserType con
         -- If the DataCon has a wrapper, then the worker's type is never seen
         -- by the user. The visibilities we pick do not matter here.
         _ -> mkInvForAllTys univ_tvs $ mkInvForAllTys ex_tvs $
                  mkFunTys rep_arg_tys $
                  mkTyConApp rep_tycon (mkTyVarTys univ_tvs)
-        -- MattP: We really should not use `setWeight` here but this makes
-        -- all the wrappers well typed. It is stop gap solution.
+        -- See Note [All data constructors have wrappers]
 
       -- See Note [Promoted data constructors] in TyCon
     prom_tv_bndrs = [ mkNamedTyConBinder vis tv
@@ -965,6 +966,7 @@ decision then this line will need to be restored. It is
 commented out to make it easy to add back with the correct
 information.
 -}
+-- TODO: arnaud: validate or invalidate this note
 
 mkCleanAnonTyConBinders :: [TyConBinder] -> [Type] -> [TyConBinder]
 -- Make sure that the "anonymous" tyvars don't clash in

--- a/compiler/basicTypes/MkId.hs
+++ b/compiler/basicTypes/MkId.hs
@@ -568,6 +568,7 @@ mkDataConRepX mkArgs mkBody fam_envs wrap_name mb_bangs data_con
 -- See Note [All data constructors have wrappers]
 --  | not wrapper_reqd
 --  = return NoDataConRep
+-- TODO: arnaud: clean this up
 
   | otherwise
   = do { wrap_args <- mkArgs wrap_arg_tys
@@ -789,10 +790,13 @@ The way we ensure this is by scaling the weight of the field by the multiplicity
 variable. This works because..
 
 1 * p = p
-w * p = w
+ω * p = ω
 
 So the arguments end up with the right multiplicity all very elegantly.
 -}
+
+-- TODO: arnaud: we've changed what data constructors have wrappers. So we will
+-- need to update the notes in this file.
 
 -------------------------
 newLocal :: Weighted Type -> UniqSM Var

--- a/compiler/coreSyn/CoreFVs.hs
+++ b/compiler/coreSyn/CoreFVs.hs
@@ -376,7 +376,7 @@ orphNamesOfCo (TyConAppCo _ tc cos) = unitNameSet (getName tc) `unionNameSet` or
 orphNamesOfCo (AppCo co1 co2)       = orphNamesOfCo co1 `unionNameSet` orphNamesOfCo co2
 orphNamesOfCo (ForAllCo _ kind_co co)
   = orphNamesOfCo kind_co `unionNameSet` orphNamesOfCo co
-orphNamesOfCo (FunCo _ _ co1 co2)   = orphNamesOfCo co1 `unionNameSet` orphNamesOfCo co2
+orphNamesOfCo (FunCo _ co_mult co1 co2) = orphNamesOfCo co_mult `unionNameSet` orphNamesOfCo co1 `unionNameSet` orphNamesOfCo co2
 orphNamesOfCo (CoVarCo _)           = emptyNameSet
 orphNamesOfCo (AxiomInstCo con _ cos) = orphNamesOfCoCon con `unionNameSet` orphNamesOfCos cos
 orphNamesOfCo (UnivCo p _ t1 t2)    = orphNamesOfProv p `unionNameSet` orphNamesOfType t1 `unionNameSet` orphNamesOfType t2

--- a/compiler/iface/IfaceSyn.hs
+++ b/compiler/iface/IfaceSyn.hs
@@ -1432,8 +1432,8 @@ freeNamesIfType (IfaceCoercionTy c)   = freeNamesIfCoercion c
 
 freeNamesIfCoercion :: IfaceCoercion -> NameSet
 freeNamesIfCoercion (IfaceReflCo _ t) = freeNamesIfType t
-freeNamesIfCoercion (IfaceFunCo _ _ c1 c2)
-  = freeNamesIfCoercion c1 &&& freeNamesIfCoercion c2
+freeNamesIfCoercion (IfaceFunCo _ c_mult c1 c2)
+  = freeNamesIfCoercion c_mult &&& freeNamesIfCoercion c1 &&& freeNamesIfCoercion c2
 freeNamesIfCoercion (IfaceTyConAppCo _ tc cos)
   = freeNamesIfTc tc &&& fnList freeNamesIfCoercion cos
 freeNamesIfCoercion (IfaceAppCo c1 c2)

--- a/compiler/iface/IfaceType.hs
+++ b/compiler/iface/IfaceType.hs
@@ -1574,7 +1574,7 @@ instance Binary IfaceCoercion where
        = pprPanic "Can't serialise IfaceFreeCoVar" (ppr cv)
   put_ _  (IfaceHoleCo cv)
        = pprPanic "Can't serialise IfaceHoleCo" (ppr cv)
-          -- See Note [Holes in IfaceUnivCoProv]
+          -- See Note [Holes in IfaceCoercion]
 
   get bh = do
       tag <- getByte bh

--- a/compiler/typecheck/TcMType.hs
+++ b/compiler/typecheck/TcMType.hs
@@ -303,7 +303,7 @@ unpackCoercionHole_maybe (CoercionHole { ch_ref = ref }) = readTcRef ref
 -- so that the input coercion is forced only when the output is forced.
 checkCoercionHole :: CoVar -> Coercion -> TcM Coercion
 checkCoercionHole cv co
-  | debugIsOn && False -- TODO: MattP disable this for now as it sometimes fails, see in particular Data.ByteString.Builder.Internal
+  | debugIsOn
   = do { cv_ty <- zonkTcType (varType cv)
                   -- co is already zonked, but cv might not be
        ; return $

--- a/compiler/typecheck/TcTyDecls.hs
+++ b/compiler/typecheck/TcTyDecls.hs
@@ -117,7 +117,7 @@ synonymTyConsOfType ty
      go_co (TyConAppCo _ tc cs)   = go_tc tc `plusNameEnv` go_co_s cs
      go_co (AppCo co co')         = go_co co `plusNameEnv` go_co co'
      go_co (ForAllCo _ co co')    = go_co co `plusNameEnv` go_co co'
-     go_co (FunCo _ _ co co')     = go_co co `plusNameEnv` go_co co'
+     go_co (FunCo _ co_mult co co') = go_co co_mult `plusNameEnv` go_co co `plusNameEnv` go_co co'
      go_co (CoVarCo _)            = emptyNameEnv
      go_co (HoleCo {})            = emptyNameEnv
      go_co (AxiomInstCo _ _ cs)   = go_co_s cs

--- a/compiler/typecheck/TcType.hs
+++ b/compiler/typecheck/TcType.hs
@@ -952,7 +952,7 @@ exactTyCoVarsOfType ty
     goCo (AppCo co arg)     = goCo co `unionVarSet` goCo arg
     goCo (ForAllCo tv k_co co)
       = goCo co `delVarSet` tv `unionVarSet` goCo k_co
-    goCo (FunCo _ _ co1 co2)   = goCo co1 `unionVarSet` goCo co2
+    goCo (FunCo _ co_mult co1 co2) = goCo co_mult `unionVarSet` goCo co1 `unionVarSet` goCo co2
     goCo (CoVarCo v)         = goVar v
     goCo (HoleCo h)          = goVar (coHoleCoVar h)
     goCo (AxiomInstCo _ _ args) = goCos args

--- a/compiler/typecheck/TcValidity.hs
+++ b/compiler/typecheck/TcValidity.hs
@@ -1931,7 +1931,7 @@ fvCo (Refl _ ty)            = fvType ty
 fvCo (TyConAppCo _ _ args)  = concatMap fvCo args
 fvCo (AppCo co arg)         = fvCo co ++ fvCo arg
 fvCo (ForAllCo tv h co)     = filter (/= tv) (fvCo co) ++ fvCo h
-fvCo (FunCo _ _ co1 co2)    = fvCo co1 ++ fvCo co2
+fvCo (FunCo _ co_mult co1 co2) = fvCo co_mult ++ fvCo co1 ++ fvCo co2
 fvCo (CoVarCo v)            = [v]
 fvCo (AxiomInstCo _ _ args) = concatMap fvCo args
 fvCo (UnivCo p _ t1 t2)     = fvProv p ++ fvType t1 ++ fvType t2

--- a/compiler/types/Coercion.hs
+++ b/compiler/types/Coercion.hs
@@ -221,9 +221,9 @@ Remember that
   (->) :: forall r1 r2. TYPE r1 -> TYPE r2 -> TYPE LiftedRep
 
 Hence
-  FunCo r co1 co2 :: (s1->t1) ~r (s2->t2)
+  FunCo r mult co1 co2 :: (s1->t1) ~r (s2->t2)
 is short for
-  TyConAppCo (->) co_rep1 co_rep2 co1 co2
+  TyConAppCo (->) mult co_rep1 co_rep2 co1 co2
 where co_rep1, co_rep2 are the coercions on the representations.
 -}
 
@@ -244,15 +244,12 @@ decomposeCo arity co rs
 decomposeFunCo :: HasDebugCallStack
                => Role      -- Role of the input coercion
                -> Coercion  -- Input coercion
-               -> (Coercion, Coercion)
+               -> (Coercion, Coercion, Coercion)
 -- Expects co :: (s1 -> t1) ~ (s2 -> t2)
 -- Returns (co1 :: s1~s2, co2 :: t1~t2)
 -- See Note [Function coercions] for the "3" and "4"
--- Include this list here to that grepping for a list of exactly
--- length 5 points to here.
--- [w, r1, r2, a1, a2]
 decomposeFunCo r co = ASSERT2( all_ok, ppr co )
-                      (mkNthCo r 3 co, mkNthCo r 4 co)
+                      (mkNthCo r 0 co, mkNthCo r 3 co, mkNthCo r 4 co)
   where
     Pair s1t1 s2t2 = coercionKind co
     all_ok = isFunTy s1t1 && isFunTy s2t2
@@ -298,7 +295,9 @@ decomposePiCos orig_kind orig_args orig_co = go [] orig_subst orig_kind orig_arg
         --          ty :: s2
         -- need arg_co :: s2 ~ s1
         --      res_co :: t1 ~ t2
-      = let (sym_arg_co, res_co) = decomposeFunCo Nominal co
+      = let (_, sym_arg_co, res_co) = decomposeFunCo Nominal co
+            -- TODO: arnaud: because the coercion must be nominal, I believe it
+            -- means we can safely ignore the multiplicity argument.<
             arg_co               = mkSymCo sym_arg_co
         in
         go (arg_co : acc_arg_cos) subst res_ki tys res_co
@@ -893,21 +892,20 @@ mkNthCo r n co
 
     go r n co@(FunCo r0 w arg res)
       -- See Note [Function coercions]
-      -- If FunCo _ arg_co res_co ::   (s1:TYPE sk1 -> s2:TYPE sk2)
-      --                             ~ (t1:TYPE tk1 -> t2:TYPE tk2)
+      -- If FunCo _ mult arg_co res_co ::   (s1:TYPE sk1 :mult-> s2:TYPE sk2)
+      --                                  ~ (t1:TYPE tk1 :mult-> t2:TYPE tk2)
       -- Then we want to behave as if co was
-      --    TyConAppCo argk_co resk_co arg_co res_co
+      --    TyConAppCo mult argk_co resk_co arg_co res_co
       -- where
       --    argk_co :: sk1 ~ tk1  =  mkNthCo 0 (mkKindCo arg_co)
       --    resk_co :: sk2 ~ tk2  =  mkNthCo 0 (mkKindCo res_co)
       --                             i.e. mkRuntimeRepCo
       = case n of
-          -- TODO: MattP, this is probably wrong, the correct coercion
-          -- needs to be placed here. And need to update the comment
+          -- TODO: MattP, There may be comments to update.
           -- Include this list here to that grepping for a list of exactly
           -- length 5 points to here.
           -- [w, r1, r2, a1, a2]
-          0 -> pprPanic "multiplicityCo" (ppr co)
+          0 -> ASSERT( r == r0 )      w
           1 -> ASSERT( r == Nominal ) mkRuntimeRepCo arg
           2 -> ASSERT( r == Nominal ) mkRuntimeRepCo res
           3 -> ASSERT( r == r0 )      arg

--- a/compiler/types/Coercion.hs
+++ b/compiler/types/Coercion.hs
@@ -332,7 +332,7 @@ splitTyConAppCo_maybe (FunCo _ w arg res)     = Just (funTyCon, cos)
   where cos = [w, mkRuntimeRepCo arg, mkRuntimeRepCo res, arg, res]
 splitTyConAppCo_maybe _                     = Nothing
 
--- TODO: This is wrong and should be ripped out when I change
+-- TODO: MattP: This is wrong and should be ripped out when I change
 -- Rig to Coercion in FunCo.
 rigToCo :: Rig -> Coercion
 rigToCo r = mkNomReflCo (rigToType r)

--- a/compiler/types/FamInstEnv.hs
+++ b/compiler/types/FamInstEnv.hs
@@ -1629,7 +1629,7 @@ allTyVarsInTy = go
     go_co (AppCo co arg)        = go_co co `unionVarSet` go_co arg
     go_co (ForAllCo tv h co)
       = unionVarSets [unitVarSet tv, go_co co, go_co h]
-    go_co (FunCo _ _ c1 c2)     = go_co c1 `unionVarSet` go_co c2
+    go_co (FunCo _ co_mult c1 c2) = go_co co_mult `unionVarSet` go_co c1 `unionVarSet` go_co c2
     go_co (CoVarCo cv)          = unitVarSet cv
     go_co (HoleCo h)            = unitVarSet (coHoleCoVar h)
     go_co (AxiomInstCo _ _ cos) = go_cos cos

--- a/compiler/types/TyCoRep.hs
+++ b/compiler/types/TyCoRep.hs
@@ -924,7 +924,6 @@ data Coercion
   | ForAllCo TyVar KindCoercion Coercion
          -- ForAllCo :: _ -> N -> e -> e
 
-  -- TODO: Change this Rig to coercion
   | FunCo Role Coercion Coercion Coercion         -- lift FunTy
          -- FunCo :: "e" -> e -> e -> e
 

--- a/compiler/types/Type.hs
+++ b/compiler/types/Type.hs
@@ -2471,7 +2471,7 @@ tyConsOfType ty
      go_co (TyConAppCo _ tc args)  = go_tc tc `unionUniqSets` go_cos args
      go_co (AppCo co arg)          = go_co co `unionUniqSets` go_co arg
      go_co (ForAllCo _ kind_co co) = go_co kind_co `unionUniqSets` go_co co
-     go_co (FunCo _ _ co1 co2)     = go_co co1 `unionUniqSets` go_co co2
+     go_co (FunCo _ co_mult co1 co2) = go_co co_mult `unionUniqSets` go_co co1 `unionUniqSets` go_co co2
      go_co (AxiomInstCo ax _ args) = go_ax ax `unionUniqSets` go_cos args
      go_co (UnivCo p _ t1 t2)      = go_prov p `unionUniqSets` go t1 `unionUniqSets` go t2
      go_co (CoVarCo {})            = emptyUniqSet

--- a/compiler/types/Type.hs
+++ b/compiler/types/Type.hs
@@ -569,7 +569,7 @@ mapCoercion mapper@(TyCoMapper { tcm_smart = smart, tcm_covar = covar
            ; co' <- mapCoercion mapper env' co
            ; return $ mkforallco tv' kind_co' co' }
         -- See Note [Efficiency for mapCoercion ForAllCo case]
-    go (FunCo r w c1 c2) = mkFunCo r w <$> go c1 <*> go c2
+    go (FunCo r w c1 c2) = mkFunCo r <$> go w <*> go c1 <*> go c2
     go (CoVarCo cv) = covar env cv
     go (AxiomInstCo ax i args)
       = mkaxiominstco ax i <$> mapM go args

--- a/compiler/types/Unify.hs
+++ b/compiler/types/Unify.hs
@@ -954,7 +954,8 @@ unify_ty env (CoercionTy co1) (CoercionTy co2) kco
              , not (cv `elemVarEnv` c_subst)
              , BindMe <- tvBindFlag env cv
              -> do { checkRnEnv env (tyCoVarsOfCo co2)
-                   ; let (co_l, co_r) = decomposeFunCo Nominal kco
+                   ; let (_, co_l, co_r) = decomposeFunCo Nominal kco
+                     -- TODO: arnaud: because the coercion is nominal, I believe we can safely ignore the multiplicity coercion.
                       -- cv :: t1 ~ t2
                       -- co2 :: s1 ~ s2
                       -- co_l :: t1 ~ s1


### PR DESCRIPTION
Don't push coercions through lambdas or application if they change the multiplicity. This is done, concretely, by checking whether the multiplicity component of the coercion is a reflexivity before pushing a coercion.