### PR TITLE
Enforce more invariants on the internal multiplicity datatype

### DIFF
--- a/compiler/basicTypes/ConLike.hs
+++ b/compiler/basicTypes/ConLike.hs
@@ -35,7 +35,7 @@ import Unique
 import Util
 import Name
 import BasicTypes
-import TyCoRep (Type, ThetaType)
+import TyCoRep (Type, ThetaType, Weighted)
 import Var
 import Type (mkTyConApp)
 import Weight

--- a/compiler/basicTypes/DataCon.hs
+++ b/compiler/basicTypes/DataCon.hs
@@ -1264,7 +1264,7 @@ dataConUserType (MkData { dcUserTyVarBinders = user_tvbs,
   = let tvb = mkTyVarBinder Inferred multiplicityTyVar
         ty  = mkTyVarTy multiplicityTyVar
         -- See Note [Wrapper weights]
-        arg_tys' = map (scaleWeighted (RigTy ty)) arg_tys
+        arg_tys' = map (scaleWeighted (RigThing ty)) arg_tys
     in
       mkForAllTys (tvb : user_tvbs) $
       mkFunTys (map unrestricted theta) $

--- a/compiler/basicTypes/DataCon.hs-boot
+++ b/compiler/basicTypes/DataCon.hs-boot
@@ -8,7 +8,7 @@ import FieldLabel ( FieldLabel )
 import Unique ( Uniquable )
 import Outputable ( Outputable, OutputableBndr )
 import BasicTypes (Arity)
-import {-# SOURCE #-} TyCoRep ( Type, ThetaType )
+import {-# SOURCE #-} TyCoRep ( Type, ThetaType, Weighted )
 import Weight
 import Util (  HasCallStack )
 

--- a/compiler/basicTypes/MkId.hs
+++ b/compiler/basicTypes/MkId.hs
@@ -638,7 +638,7 @@ mkDataConRepX mkArgs mkBody fam_envs wrap_name mb_bangs data_con
     ev_ibangs    = map (const HsLazy) ev_tys
     orig_bangs   = dataConSrcBangs data_con
 
-    w_ty = RigTy (mkTyVarTy multiplicityTyVar)
+    w_ty = RigThing (mkTyVarTy multiplicityTyVar)
     -- See Note [Wrapper weights]
     wrap_arg_tys = (map unrestricted theta)
                     ++ (map (scaleWeighted w_ty) orig_arg_tys)

--- a/compiler/basicTypes/Var.hs
+++ b/compiler/basicTypes/Var.hs
@@ -84,7 +84,7 @@ module Var (
 
 import GhcPrelude
 
-import {-# SOURCE #-}   TyCoRep( Type, Kind, pprKind, pprType)
+import {-# SOURCE #-}   TyCoRep( Type, Kind, pprKind, pprType, Rig )
 import {-# SOURCE #-}   TcType( TcTyVarDetails, pprTcTyVarDetails, vanillaSkolemTv )
 import {-# SOURCE #-}   IdInfo( IdDetails, IdInfo, coVarDetails, isCoVarDetails,
                                 vanillaIdInfo, pprIdDetails )

--- a/compiler/deSugar/DsArrows.hs
+++ b/compiler/deSugar/DsArrows.hs
@@ -32,6 +32,7 @@ import {-# SOURCE #-} DsExpr ( dsExpr, dsLExpr, dsLExprNoLP, dsLocalBinds, dsSyn
 
 import TcType
 import Type ( splitPiTy )
+import Weight
 import TcEvidence
 import CoreSyn
 import CoreFVs

--- a/compiler/deSugar/DsExpr.hs
+++ b/compiler/deSugar/DsExpr.hs
@@ -376,7 +376,7 @@ ds_expr _ (ExplicitTuple _ tup_args boxity)
                     -- For every missing expression, we need
                     -- another lambda in the desugaring. This lambda is linear
                     -- since tuples are linear
-               = do { lam_var <- newSysLocalDsNoLP (RigTy (mkTyVarTy multiplicityTyVar)) ty
+               = do { lam_var <- newSysLocalDsNoLP (RigThing (mkTyVarTy multiplicityTyVar)) ty
                     ; return (lam_var : lam_vars, Var lam_var : args, True) }
              go (lam_vars, args, missing) (L _ (Present _ expr))
                     -- Expressions that are present don't generate

--- a/compiler/deSugar/DsMeta.hs
+++ b/compiler/deSugar/DsMeta.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP, TypeFamilies #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE PatternSynonyms #-}
 
 -----------------------------------------------------------------------------
 --
@@ -47,6 +48,7 @@ import NameSet
 import TcType
 import TyCon
 import TysWiredIn
+import Weight ( pattern Omega )
 import CoreSyn
 import MkCore
 import CoreUtils

--- a/compiler/deSugar/Match.hs-boot
+++ b/compiler/deSugar/Match.hs-boot
@@ -8,7 +8,7 @@ import CoreSyn  ( CoreExpr )
 import HsSyn    ( LPat, HsMatchContext, MatchGroup, LHsExpr )
 import Name     ( Name )
 import HsExtension ( GhcTc )
-import Weight   ( Rig )
+import Type   ( Rig )
 
 match   :: [Id]
         -> Type

--- a/compiler/deSugar/MatchCon.hs
+++ b/compiler/deSugar/MatchCon.hs
@@ -22,6 +22,7 @@ import DsBinds
 import ConLike
 import TcType
 import Weight
+import Type ( Weighted )
 import DsMonad
 import DsUtils
 import MkCore   ( mkCoreLets )

--- a/compiler/ghci/ByteCodeGen.hs
+++ b/compiler/ghci/ByteCodeGen.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP, MagicHash, RecordWildCards, BangPatterns #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving, PatternSynonyms #-}
 {-# OPTIONS_GHC -fprof-auto-top #-}
 --
 --  (c) The University of Glasgow 2002-2006
@@ -34,6 +34,7 @@ import PprCore
 import Literal
 import PrimOp
 import CoreFVs
+import Weight ( pattern Omega )
 import Type
 import RepType
 import Kind            ( isLiftedTypeKind )

--- a/compiler/hsSyn/HsUtils.hs
+++ b/compiler/hsSyn/HsUtils.hs
@@ -17,6 +17,7 @@ which deal with the instantiated versions are located elsewhere:
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE PatternSynonyms #-}
 
 module HsUtils(
   -- Terms
@@ -104,6 +105,7 @@ import TcEvidence
 import RdrName
 import Var
 import TyCoRep
+import Weight ( pattern Zero, pattern One, pattern Omega )
 import Type   ( filterOutInvisibleTypes )
 import TysWiredIn ( unitTy, omegaDataConTy )
 import TcType

--- a/compiler/iface/MkIface.hs
+++ b/compiler/iface/MkIface.hs
@@ -1692,7 +1692,7 @@ tyConToIfaceDecl env tycon
                     ifConEqSpec  = map (to_eq_spec . eqSpecPair) eq_spec,
                     ifConCtxt    = tidyToIfaceContext con_env2 theta,
                     ifConArgTys  =
-                      map (\(Weighted w t) -> (tidyToIfaceType con_env2 (rigToType w)
+                      map (\(Weighted w t) -> (tidyToIfaceType con_env2 (fromMult w)
                                         , (tidyToIfaceType con_env2 t))) arg_tys,
                     ifConFields  = dataConFieldLabels data_con,
                     ifConStricts = map (toIfaceBang con_env2)

--- a/compiler/iface/TcIface.hs
+++ b/compiler/iface/TcIface.hs
@@ -1286,7 +1286,7 @@ tcIfaceType = go
     go (IfaceCoercionTy co)  = CoercionTy <$> tcIfaceCo co
 
 tcIfaceRig :: IfaceType -> IfL Rig
-tcIfaceRig if_ty = typeToRig <$> tcIfaceType if_ty
+tcIfaceRig if_ty = toMult <$> tcIfaceType if_ty
 
 tcIfaceTupleTy :: TupleSort -> IsPromoted -> IfaceTcArgs -> IfL Type
 tcIfaceTupleTy sort is_promoted args

--- a/compiler/iface/ToIface.hs
+++ b/compiler/iface/ToIface.hs
@@ -172,7 +172,7 @@ toIfaceForAllBndrX :: VarSet -> TyVarBinder -> IfaceForAllBndr
 toIfaceForAllBndrX fr (TvBndr v vis) = TvBndr (toIfaceTvBndrX fr v) vis
 
 toIfaceRig :: Rig -> IfaceRig
-toIfaceRig = toIfaceType . rigToType
+toIfaceRig = toIfaceType . fromMult
 
 ----------------
 toIfaceTyCon :: TyCon -> IfaceTyCon

--- a/compiler/prelude/PrelInfo.hs
+++ b/compiler/prelude/PrelInfo.hs
@@ -62,7 +62,6 @@ import Id
 import Name
 import NameEnv
 import MkId
-import Weight           ( Rig(..) )
 import Outputable
 import TysPrim
 import TysWiredIn

--- a/compiler/simplCore/Exitify.hs
+++ b/compiler/simplCore/Exitify.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE PatternSynonyms #-}
+
 module Exitify ( exitifyProgram ) where
 
 {-
@@ -48,6 +50,7 @@ import VarEnv
 import CoreFVs
 import FastString
 import Type
+import Weight ( pattern Omega )
 import Util( mapSnd )
 
 import Data.Bifunctor

--- a/compiler/simplCore/SAT.hs
+++ b/compiler/simplCore/SAT.hs
@@ -48,7 +48,7 @@ The previous patch, to fix polymorphic floatout demand signatures, is
 essential to make this work well!
 -}
 
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP, PatternSynonyms #-}
 module SAT ( doStaticArgs ) where
 
 import GhcPrelude
@@ -56,6 +56,7 @@ import GhcPrelude
 import Var
 import CoreSyn
 import CoreUtils
+import Weight ( pattern Omega )
 import Type
 import Coercion
 import Id

--- a/compiler/simplCore/SetLevels.hs
+++ b/compiler/simplCore/SetLevels.hs
@@ -49,7 +49,7 @@
   the scrutinee of the case, and we can inline it.
 -}
 
-{-# LANGUAGE CPP, MultiWayIf #-}
+{-# LANGUAGE CPP, MultiWayIf, PatternSynonyms #-}
 module SetLevels (
         setLevels,
 
@@ -87,7 +87,8 @@ import Literal          ( litIsTrivial )
 import Demand           ( StrictSig, Demand, isStrictDmd, splitStrictSig, increaseStrictSigArity )
 import Name             ( getOccName, mkSystemVarName )
 import OccName          ( occNameString )
-import Type             ( Type, mkLamTypes, splitTyConApp_maybe, tyCoVarsOfType, Rig(..) )
+import Type             ( Type, mkLamTypes, splitTyConApp_maybe, tyCoVarsOfType, Rig )
+import Weight           ( pattern Omega )
 import BasicTypes       ( Arity, RecFlag(..), isRec )
 import DataCon          ( dataConOrigResTy )
 import TysWiredIn

--- a/compiler/simplCore/SimplEnv.hs
+++ b/compiler/simplCore/SimplEnv.hs
@@ -61,6 +61,7 @@ import DynFlags                 ( DynFlags )
 import TysWiredIn
 import qualified Type
 import Type hiding              ( substTy, substTyVar, substTyVarBndr )
+import Weight
 import qualified Coercion
 import Coercion hiding          ( substCo, substCoVar, substCoVarBndr )
 import BasicTypes

--- a/compiler/simplCore/SimplMonad.hs
+++ b/compiler/simplCore/SimplMonad.hs
@@ -26,6 +26,7 @@ import Name             ( mkSystemVarName )
 import Id               ( Id, mkSysLocalOrCoVar, idWeight )
 import IdInfo           ( IdDetails(..), vanillaIdInfo, setArityInfo )
 import Type             ( Type, mkLamTypes, Rig(..))
+import Weight
 import FamInstEnv       ( FamInstEnv )
 import CoreSyn          ( RuleEnv(..) )
 import UniqSupply

--- a/compiler/simplStg/UnariseStg.hs
+++ b/compiler/simplStg/UnariseStg.hs
@@ -190,7 +190,7 @@ STG programs after unarisation have these invariants:
   * Alt binders (binders in patterns) are always non-void.
 -}
 
-{-# LANGUAGE CPP, TupleSections #-}
+{-# LANGUAGE CPP, TupleSections, PatternSynonyms #-}
 
 module UnariseStg (unarise) where
 
@@ -216,6 +216,7 @@ import TysWiredIn
 import UniqSupply
 import Util
 import VarEnv
+import Weight ( pattern Omega )
 
 import Data.Bifunctor (second)
 import Data.Maybe (mapMaybe)

--- a/compiler/specialise/Specialise.hs
+++ b/compiler/specialise/Specialise.hs
@@ -4,7 +4,7 @@
 \section[Specialise]{Stamping out overloading, and (optionally) polymorphism}
 -}
 
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP, PatternSynonyms #-}
 module Specialise ( specProgram, specUnfolding ) where
 
 #include "HsVersions.h"
@@ -14,6 +14,7 @@ import GhcPrelude
 import Id
 import TcType hiding( substTy )
 import Type   hiding( substTy, extendTvSubstList )
+import Weight ( pattern Omega )
 import Module( Module, HasModule(..) )
 import Coercion( Coercion )
 import CoreMonad

--- a/compiler/stranal/WwLib.hs
+++ b/compiler/stranal/WwLib.hs
@@ -755,7 +755,7 @@ deepSplitCprType_maybe _ _ _ = Nothing
 -- non-linear multiplicity, document and move to a more appropriate place.
 isLinear :: Weighted a -> Bool
 isLinear (Weighted w _ ) =
-  case flattenRig w of
+  case w of
     One -> True
     _ -> False
 

--- a/compiler/typecheck/TcCanonical.hs
+++ b/compiler/typecheck/TcCanonical.hs
@@ -2094,7 +2094,7 @@ unifyWanted loc role orig_ty1 orig_ty2
     go (FunTy w1 s1 t1) (FunTy w2 s2 t2)
       = do { co_s <- unifyWanted loc role s1 s2
            ; co_t <- unifyWanted loc role t1 t2
-           ; co_w <- unifyWanted loc Nominal (rigToType w1) (rigToType w2)
+           ; co_w <- unifyWanted loc Nominal (fromMult w1) (fromMult w2)
            ; return (mkFunCo role co_w co_s co_t) }
     go (TyConApp tc1 tys1) (TyConApp tc2 tys2)
       | tc1 == tc2, tys1 `equalLength` tys2

--- a/compiler/typecheck/TcClassDcl.hs
+++ b/compiler/typecheck/TcClassDcl.hs
@@ -31,7 +31,7 @@ import TcUnify
 import TcHsType
 import TcMType
 import Type     ( getClassPredTys_maybe, piResultTys )
-import Weight   ( unrestricted )
+import Weight
 import TcType
 import TcRnMonad
 import DriverPhases (HscSource(..))

--- a/compiler/typecheck/TcExpr.hs
+++ b/compiler/typecheck/TcExpr.hs
@@ -523,7 +523,7 @@ tcExpr expr@(ExplicitTuple x tup_args boxity) res_ty
                  -- relevant.
                  -- MattP: I made this polymorphic on 26-06-2018
                  =  mkForAllTys [w_tvb] $
-                    mkFunTys [ mkWeighted (RigTy w_ty) ty | (ty, (L _ (Missing _))) <- arg_tys `zip` tup_args]
+                    mkFunTys [ mkWeighted (RigThing w_ty) ty | (ty, (L _ (Missing _))) <- arg_tys `zip` tup_args]
                             (mkTupleTy boxity arg_tys)
 
        ; wrap <- tcSubTypeHR (Shouldn'tHappenOrigin "ExpTuple")

--- a/compiler/typecheck/TcExpr.hs-boot
+++ b/compiler/typecheck/TcExpr.hs-boot
@@ -3,6 +3,7 @@ import Name
 import HsSyn    ( HsExpr, LHsExpr, SyntaxExpr )
 import TcType   ( TcRhoType, TcSigmaType, SyntaxOpType, ExpType, ExpRhoType )
 import Weight
+import Type ( Rig )
 import TcRnTypes( TcM, CtOrigin )
 import HsExtension ( GhcRn, GhcTcId )
 

--- a/compiler/typecheck/TcFlatten.hs
+++ b/compiler/typecheck/TcFlatten.hs
@@ -1388,9 +1388,9 @@ flatten_one (TyConApp tc tys)
 flatten_one (FunTy weight ty1 ty2)
   = do { (xi1,co1) <- flatten_one ty1
        ; (xi2,co2) <- flatten_one ty2
-       ; (xi3, co3) <- flatten_one (rigToType weight)
+       ; (xi3, co3) <- flatten_one (fromMult weight)
        ; role <- getRole
-       ; return (mkFunTy (typeToRig xi3) xi1 xi2, mkFunCo role co3 co1 co2) }
+       ; return (mkFunTy (toMult xi3) xi1 xi2, mkFunCo role co3 co1 co2) }
 
 flatten_one ty@(ForAllTy {})
 -- TODO (RAE): This is inadequate, as it doesn't flatten the kind of

--- a/compiler/typecheck/TcHsSyn.hs
+++ b/compiler/typecheck/TcHsSyn.hs
@@ -1718,7 +1718,7 @@ zonkWeightedTcTypeToType env (Weighted r ty) = Weighted <$> zonkRig env r
                                                         <*> zonkTcTypeToType env ty
 
 zonkRig :: ZonkEnv -> Rig -> TcM Rig
-zonkRig env (RigTy t) = RigTy <$> zonkTcTypeToType env t
+zonkRig env (RigThing t) = RigThing <$> zonkTcTypeToType env t
 zonkRig env (RigAdd m1 m2) = RigAdd <$> zonkRig env m1 <*> zonkRig env m2
 zonkRig env (RigMul m1 m2) = RigMul <$> zonkRig env m1 <*> zonkRig env m2
 zonkRig env r = return r

--- a/compiler/typecheck/TcHsType.hs
+++ b/compiler/typecheck/TcHsType.hs
@@ -611,7 +611,7 @@ tc_weight mode r = case r of
                           case ty' of
                             t | isOneMultiplicity t -> return One
                             t | isOmegaMultiplicity t -> return Omega
-                            t -> return $ RigTy t
+                            t -> return $ RigThing t
                          _ -> panic "tc_weight: polymorphism"
 
 

--- a/compiler/typecheck/TcMType.hs
+++ b/compiler/typecheck/TcMType.hs
@@ -9,7 +9,7 @@ This module contains monadic operations over types that contain
 mutable type variables
 -}
 
-{-# LANGUAGE CPP, TupleSections, MultiWayIf #-}
+{-# LANGUAGE CPP, TupleSections, MultiWayIf, PatternSynonyms #-}
 
 module TcMType (
   TcTyVar, TcKind, TcType, TcTauType, TcThetaType, TcTyVarSet,
@@ -101,6 +101,7 @@ import GhcPrelude
 import TyCoRep
 import TcType
 import Type
+import Weight ( pattern Omega )
 import Kind
 import Coercion
 import Class

--- a/compiler/typecheck/TcMatches.hs
+++ b/compiler/typecheck/TcMatches.hs
@@ -30,6 +30,7 @@ import TcRnMonad
 import TcEnv
 import TcPat
 import Weight
+import Type ( Weighted )
 import UsageEnv
 import TcMType
 import TcType

--- a/compiler/typecheck/TcPat.hs
+++ b/compiler/typecheck/TcPat.hs
@@ -34,7 +34,7 @@ import UsageEnv (subweight)
 import TcEnv
 import TcMType
 import TcValidity( arityErr )
-import Type ( pprTyVars )
+import Type ( Weighted, pprTyVars )
 import TcType
 import TcUnify
 import TcHsType

--- a/compiler/typecheck/TcType.hs
+++ b/compiler/typecheck/TcType.hs
@@ -942,7 +942,7 @@ exactTyCoVarsOfType ty
     go (CastTy ty co)       = go ty `unionVarSet` goCo co
     go (CoercionTy co)      = goCo co
 
-    go_rig (RigTy ty)       = go ty
+    go_rig (RigThing ty)       = go ty
     go_rig (RigAdd m1 m2)   = go_rig m1 `unionVarSet` go_rig m2
     go_rig (RigMul m1 m2)   = go_rig m1 `unionVarSet` go_rig m2
     go_rig _                = emptyVarSet
@@ -1002,7 +1002,7 @@ anyRewritableTyVar ignore_cos role pred ty
     go rl bvs (CastTy ty co)    = go rl bvs ty || go_co rl bvs co
     go rl bvs (CoercionTy co)   = go_co rl bvs co  -- ToDo: check
 
-    go_rig rl bvs (RigTy ty) = go rl bvs ty
+    go_rig rl bvs (RigThing ty) = go rl bvs ty
     go_rig rl bvs (RigAdd m1 m2) = go_rig rl bvs m1 || go_rig rl bvs m2
     go_rig rl bvs (RigMul m1 m2) = go_rig rl bvs m1 || go_rig rl bvs m2
     go_rig _ _ _ = False
@@ -1172,7 +1172,7 @@ split_dvs bound dvs ty
       where
         DV { dv_kvs = kvs, dv_tvs = tvs } = split_dvs (bound `extendVarSet` tv) dv ty
 
-    go_rig dv (RigTy ty) =  go dv ty
+    go_rig dv (RigThing ty) =  go dv ty
     go_rig dv (RigAdd m1 m2) = go_rig dv m1 `mappend` go_rig dv m2
     go_rig dv (RigMul m1 m2) = go_rig dv m1 `mappend` go_rig dv m2
     go_rig dv _              = dv
@@ -1627,7 +1627,7 @@ tcRepSplitTyConApp_maybe' (TyConApp tc tys)          = Just (tc, tys)
 tcRepSplitTyConApp_maybe' (FunTy w arg res)
   | Just arg_rep <- getRuntimeRep_maybe arg
   , Just res_rep <- getRuntimeRep_maybe res
-  = Just (funTyCon, [rigToType w, arg_rep, res_rep, arg, res])
+  = Just (funTyCon, [fromMult w, arg_rep, res_rep, arg, res])
 tcRepSplitTyConApp_maybe' _                          = Nothing
 
 

--- a/compiler/typecheck/TcUnify.hs
+++ b/compiler/typecheck/TcUnify.hs
@@ -825,7 +825,7 @@ tc_sub_type_ds eq_orig inst_orig ctxt ty_actual ty_expected
 
 tc_sub_weight_ds :: CtOrigin -> CtOrigin -> UserTypeCtxt -> Rig -> Rig -> TcM HsWrapper
 tc_sub_weight_ds eq_orig inst_orig ctxt w_actual w_expected =
-  tc_sub_type_ds eq_orig inst_orig ctxt (rigToType w_actual) (rigToType w_expected)
+  tc_sub_type_ds eq_orig inst_orig ctxt (fromMult w_actual) (fromMult w_expected)
 
 -- TODO: MattP fix the origins
 -- As an approximation to checking w1 * w2 <= w we check that w1 <= w and
@@ -1379,7 +1379,7 @@ uType t_or_k origin orig_ty1 orig_ty2
     go (FunTy w1 fun1 arg1) (FunTy w2 fun2 arg2)
       = do { co_l <- uType t_or_k origin fun1 fun2
            ; co_r <- uType t_or_k origin arg1 arg2
-           ; co_w <- uType t_or_k origin (rigToType w1) (rigToType w2)
+           ; co_w <- uType t_or_k origin (fromMult w1) (fromMult w2)
            ; return $ mkFunCo Nominal co_w co_l co_r }
 
         -- Always defer if a type synonym family (type function)

--- a/compiler/types/FamInstEnv.hs
+++ b/compiler/types/FamInstEnv.hs
@@ -41,6 +41,7 @@ module FamInstEnv (
 import GhcPrelude
 
 import Unify
+import Weight
 import Type
 import TyCoRep
 import TyCon
@@ -1364,9 +1365,9 @@ normalise_type ty
     go (FunTy w ty1 ty2)
       = do { (co1, nty1) <- go ty1
            ; (co2, nty2) <- go ty2
-           ; (wco, wty) <- go (rigToType w)
+           ; (wco, wty) <- go (fromMult w)
            ; r <- getRole
-           ; return (mkFunCo r wco co1 co2, mkFunTy (typeToRig wty) nty1 nty2) }
+           ; return (mkFunCo r wco co1 co2, mkFunTy (toMult wty) nty1 nty2) }
     go (ForAllTy (TvBndr tyvar vis) ty)
       = do { (lc', tv', h, ki') <- normalise_tyvar_bndr tyvar
            ; (co, nty)          <- withLC lc' $ normalise_type ty

--- a/compiler/types/TyCoRep.hs-boot
+++ b/compiler/types/TyCoRep.hs-boot
@@ -4,6 +4,7 @@ import GhcPrelude
 
 import Outputable ( SDoc )
 import Data.Data  ( Data )
+import Weight
 
 data Type
 data TyThing
@@ -25,3 +26,7 @@ isMultiplicityTy :: Type -> Bool
 
 instance Data Type
   -- To support Data instances in CoAxiom
+
+type Rig = GMult Type
+type Weighted = GWeighted Type
+instance Multable Type

--- a/compiler/types/UsageEnv.hs
+++ b/compiler/types/UsageEnv.hs
@@ -6,10 +6,12 @@ import Weight
 import NameEnv
 import Outputable
 import Name
-import Type (flattenRig)
+import TyCoRep ( Rig, Weighted )
 
 import Control.Monad
 import Data.Maybe
+
+-- TODO: arnaud: try and make this non-recursive with the rest
 
 --
 -- * Usage environments
@@ -108,10 +110,12 @@ instance Outputable IsSubweight where
   ppr = text . show
 
 
+-- TODO: arnaud: this should move to Weight.
+
 -- | @subweight w1 w2@ check whether a value of weight @w1@ is allowed where a
 -- value of weight @w2@ is expected. This is a partial order.
-subweightMaybe :: Rig -> Rig -> IsSubweight
-subweightMaybe (flattenRig -> r1) (flattenRig -> r2) = go r1 r2
+subweightMaybe :: GMult t -> GMult t -> IsSubweight
+subweightMaybe r1 r2 = go r1 r2
   where
     go _     Omega = Smaller
     go Zero  Zero  = Smaller
@@ -125,5 +129,5 @@ subweightMaybe (flattenRig -> r1) (flattenRig -> r2) = go r1 r2
     go One   One   = Smaller
     -- The 1 <= p rule
     go One   _     = Smaller
---    go (RigTy t) (RigTy t') = Unknown
+--    go (RigThing t) (RigThing t') = Unknown
     go _     _     = Unknown

--- a/compiler/types/UsageEnv.hs-boot
+++ b/compiler/types/UsageEnv.hs-boot
@@ -4,4 +4,4 @@ import Weight
 
 data IsSubweight = Smaller | Larger | Unknown
 
-subweightMaybe :: Rig -> Rig -> IsSubweight
+subweightMaybe :: GMult t -> GMult t -> IsSubweight

--- a/compiler/vectorise/Vectorise/Builtins/Initialise.hs
+++ b/compiler/vectorise/Vectorise/Builtins/Initialise.hs
@@ -18,6 +18,7 @@ import TyCon
 import Class
 import CoreSyn
 import Type
+import Weight
 import NameEnv
 import Name
 import Id

--- a/compiler/vectorise/Vectorise/Monad/Naming.hs
+++ b/compiler/vectorise/Vectorise/Monad/Naming.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE PatternSynonyms #-}
+
 -- |Computations in the vectorisation monad concerned with naming and fresh variable generation.
 
 module Vectorise.Monad.Naming
@@ -21,6 +23,7 @@ import Vectorise.Monad.Base
 import DsMonad
 import TcType
 import Type
+import Weight ( pattern Omega )
 import Var
 import Module
 import Name

--- a/testsuite/tests/callarity/unittest/CallArity1.hs
+++ b/testsuite/tests/callarity/unittest/CallArity1.hs
@@ -1,8 +1,9 @@
-{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TupleSections, PatternSynonyms #-}
 import CoreSyn
 import CoreUtils
 import Id
 import Type
+import Weight ( pattern Omega )
 import MkCore
 import CallArity (callArityRHS)
 import MkId

--- a/testsuite/tests/parser/should_compile/DumpTypecheckedAst.stderr
+++ b/testsuite/tests/parser/should_compile/DumpTypecheckedAst.stderr
@@ -401,7 +401,7 @@
            [(TyConApp
              ({abstract:TyCon})
              [])])
-          (Omega))
+          (Omega_))
          ({ DumpTypecheckedAst.hs:11:1-23 }
           [({ DumpTypecheckedAst.hs:11:1-23 }
             (Match


### PR DESCRIPTION
Mostly: multiplicities are always maximally reified (gets rid of the
rather ad hoc `flattenRig` function)

Also decouples the Rig module from the Types mutually recursive block.