### PR TITLE
Revert obsoleted changes

### DIFF
--- a/compiler/basicTypes/Id.hs
+++ b/compiler/basicTypes/Id.hs
@@ -335,16 +335,16 @@ mkSysLocal fs uniq w ty = ASSERT( not (isCoercionType ty) )
                         mkLocalId (mkSystemVarName uniq fs) (Regular w) ty
 
 -- | Like 'mkSysLocal', but checks to see if we have a covar type
-mkSysLocalOrCoVar :: FastString -> Unique -> Rig -> Type -> Id
+mkSysLocalOrCoVar :: FastString -> Unique -> VarMult -> Type -> Id
 mkSysLocalOrCoVar fs uniq w ty
-  = mkLocalIdOrCoVar (mkSystemVarName uniq fs) (Regular w) ty
+  = mkLocalIdOrCoVar (mkSystemVarName uniq fs) w ty
 
 mkSysLocalM :: MonadUnique m => FastString -> Rig -> Type -> m Id
 mkSysLocalM fs w ty = getUniqueM >>= (\uniq -> return (mkSysLocal fs uniq w ty))
 
 mkSysLocalOrCoVarM :: MonadUnique m => FastString -> Rig -> Type -> m Id
 mkSysLocalOrCoVarM fs w ty
-  = getUniqueM >>= (\uniq -> return (mkSysLocalOrCoVar fs uniq w ty))
+  = getUniqueM >>= (\uniq -> return (mkSysLocalOrCoVar fs uniq (Regular w) ty))
 
 -- | Create a user local 'Id'. These are local 'Id's (see "Var#globalvslocal") with a name and location that the user might recognize
 mkUserLocal :: OccName -> Unique -> Rig -> Type -> SrcSpan -> Id
@@ -372,7 +372,7 @@ mkTemplateLocal :: Int -> Type -> Id
 mkTemplateLocal i ty = mkTemplateLocalW i (unrestricted ty)
 
 mkTemplateLocalW :: Int -> Weighted Type -> Id
-mkTemplateLocalW i (Weighted w ty) = mkSysLocalOrCoVar (fsLit "v") (mkBuiltinUnique i) w ty
+mkTemplateLocalW i (Weighted w ty) = mkSysLocalOrCoVar (fsLit "v") (mkBuiltinUnique i) (Regular w) ty
 
 -- | Create a template local for a series of types
 mkTemplateLocals :: [Type] -> [Id]

--- a/compiler/basicTypes/MkId.hs
+++ b/compiler/basicTypes/MkId.hs
@@ -801,7 +801,7 @@ So the arguments end up with the right multiplicity all very elegantly.
 -------------------------
 newLocal :: Weighted Type -> UniqSM Var
 newLocal (Weighted w ty) = do { uniq <- getUniqueM
-                              ; return (mkSysLocalOrCoVar (fsLit "dt") uniq w ty) }
+                              ; return (mkSysLocalOrCoVar (fsLit "dt") uniq (Regular w) ty) }
 
 -- | Unpack/Strictness decisions from source module
 dataConSrcToImplBang

--- a/compiler/coreSyn/CoreArity.hs
+++ b/compiler/coreSyn/CoreArity.hs
@@ -1150,5 +1150,5 @@ freshEtaId n subst ty
       where
         ty'     = Type.substTy subst (weightedThing ty)
         eta_id' = uniqAway (getTCvInScope subst) $
-                  mkSysLocalOrCoVar (fsLit "eta") (mkBuiltinUnique n) (weightedWeight ty) ty'
+                  mkSysLocalOrCoVar (fsLit "eta") (mkBuiltinUnique n) (Regular $ weightedWeight ty) ty'
         subst'  = extendTCvInScope subst eta_id'

--- a/compiler/simplCore/SetLevels.hs
+++ b/compiler/simplCore/SetLevels.hs
@@ -1614,7 +1614,7 @@ newPolyBndrs dest_lvl
 
     mk_poly_bndr bndr uniq = transferPolyIdInfo bndr abs_vars $         -- Note [transferPolyIdInfo] in Id.hs
                              transfer_join_info bndr $
-                             mkSysLocalOrCoVar (mkFastString str) uniq (idWeight bndr) poly_ty
+                             mkSysLocalOrCoVar (mkFastString str) uniq (idWeightedness bndr) poly_ty
                            where
                              str     = "poly_" ++ occNameString (getOccName bndr)
                              poly_ty = mkLamTypes abs_vars (CoreSubst.substTy subst (idType bndr))

--- a/compiler/simplCore/SimplEnv.hs
+++ b/compiler/simplCore/SimplEnv.hs
@@ -32,7 +32,7 @@ module SimplEnv (
         SimplFloats(..), emptyFloats, mkRecFloats,
         mkFloatBind, addLetFloats, addJoinFloats, addFloats,
         extendFloats, wrapFloats,
-        doFloatFromRhs, getTopFloatBinds, scaleLetFloatsBy, scaleFloatsBy,
+        doFloatFromRhs, getTopFloatBinds, scaleFloatsBy,
 
         -- * LetFloats
         LetFloats, letFloatBinds, emptyLetFloats, unitLetFloat,
@@ -639,13 +639,11 @@ mapLetFloats (LetFloats fs ff) fun
     app (NonRec b e) = case fun (b,e) of (b',e') -> NonRec b' e'
     app (Rec bs)     = Rec (map fun bs)
 
-scaleLetFloatsBy :: Rig -> LetFloats -> LetFloats
-scaleLetFloatsBy w lfs =
-  mapLetFloats lfs (\(bndr, e) -> (scaleIdBy bndr w, e))
-
 scaleFloatsBy :: Rig -> SimplFloats -> SimplFloats
 scaleFloatsBy w (SimplFloats lfs jfs in_scope) =
-  SimplFloats (scaleLetFloatsBy w lfs) jfs in_scope
+  SimplFloats lfs' jfs in_scope
+  where
+    lfs' = mapLetFloats lfs (\(bndr, e) -> (scaleIdBy bndr w, e))
 
 
 

--- a/compiler/simplCore/SimplMonad.hs
+++ b/compiler/simplCore/SimplMonad.hs
@@ -185,7 +185,7 @@ getFamEnvs = SM (\st_env us sc -> return (st_fams st_env, us, sc))
 
 newId :: FastString -> Rig -> Type -> SimplM Id
 newId fs w ty = do uniq <- getUniqueM
-                   return (mkSysLocalOrCoVar fs uniq w ty)
+                   return (mkSysLocalOrCoVar fs uniq (Regular w) ty)
 
 newJoinId :: [Var] -> Type -> SimplM Id
 newJoinId bndrs body_ty

--- a/compiler/simplCore/SimplUtils.hs
+++ b/compiler/simplCore/SimplUtils.hs
@@ -123,7 +123,7 @@ data SimplCont
       , sc_arg  :: InExpr       -- The argument,
       , sc_env  :: StaticEnv    -- see Note [StaticEnv invariant]
       , sc_cont :: SimplCont
-      , sc_weight :: Rig }
+      , sc_weight :: Rig } -- TODO: arnaud: not needed, I think, because the hole is in the function, not the argument.
 
   | ApplyToTy          -- (ApplyToTy ty K)[e] = K[ e ty ]
       { sc_arg_ty  :: OutType     -- Argument type
@@ -414,11 +414,11 @@ contHoleType (TickIt _ k)                     = contHoleType k
 contHoleType (CastIt co _)                    = pFst (coercionKind co)
 contHoleType (StrictBind { sc_bndr = b, sc_dup = dup, sc_env = se })
   = perhapsSubstTy dup se (idType b)
-contHoleType (StrictArg  { sc_fun = ai })      = funArgTy (ai_type ai)
+contHoleType (StrictArg  { sc_fun = ai, sc_weight = _w })      = funArgTy (ai_type ai) -- MattP: This looks dodgy as sc_weight is not used.
 contHoleType (ApplyToTy  { sc_hole_ty = ty }) = ty  -- See Note [The hole type in ApplyToTy]
 contHoleType (ApplyToVal { sc_arg = e, sc_env = se, sc_dup = dup, sc_cont = k
                          , sc_weight = w })
-  = mkFunTy w (perhapsSubstTy dup se (exprType e))
+  = mkFunTy w (perhapsSubstTy dup se (exprType e)) -- TODO: arnaud: It's probably not _always_ Omega here.
                   (contHoleType k)
 contHoleType (Select { sc_dup = d, sc_bndr =  b, sc_env = se })
   = perhapsSubstTy d se (idType b)

--- a/compiler/simplCore/Simplify.hs
+++ b/compiler/simplCore/Simplify.hs
@@ -297,7 +297,7 @@ simplLazyBind env top_lvl is_rec bndr bndr1 rhs rhs_se
 
         ; (bind_float, env2) <- completeBind (env `setInScopeFromF` rhs_floats)
                                              top_lvl Nothing bndr bndr1 rhs'
-        ; return (scaleFloatsBy (idWeight bndr1) rhs_floats `addFloats` bind_float, env2) }
+        ; return (rhs_floats `addFloats` bind_float, env2) }
 
 --------------------------
 simplJoinBind :: SimplEnv
@@ -362,8 +362,7 @@ completeNonRecX top_lvl env is_strict old_bndr new_bndr new_rhs
         ; (bind_float, env2) <- completeBind (env `setInScopeFromF` rhs_floats)
                                              NotTopLevel Nothing
                                              old_bndr new_bndr rhs2
-        ; let scaled_rhs_floats = scaleFloatsBy (idWeight new_bndr) rhs_floats
-        ; return (scaled_rhs_floats `addFloats` bind_float, env2) }
+        ; return (rhs_floats `addFloats` bind_float, env2) }
 
 
 {- *********************************************************************
@@ -425,12 +424,7 @@ prepareRhs mode top_lvl occ _ rhs0
              ; case is_exp of
                 False -> return (False, emptyLetFloats, App fun arg)
                 True  -> do { (floats2, arg') <- makeTrivial mode top_lvl occ arg
-                            ; let scaled_floats2 = scaleLetFloatsBy arg_mult floats2
-                            ; return (True, floats1 `addLetFlts` scaled_floats2, App fun' arg') } }
-        where
-          (Weighted arg_mult _, _) = splitFunTy fun_ty
-          fun_ty = exprType fun
-
+                            ; return (True, floats1 `addLetFlts` floats2, App fun' arg') } }
     go n_val_args (Var fun)
         = return (is_exp, emptyLetFloats, Var fun)
         where
@@ -512,8 +506,8 @@ These strange casts can happen as a result of case-of-case
 makeTrivialArg :: SimplMode -> ArgSpec -> SimplM (LetFloats, ArgSpec)
 makeTrivialArg mode (ValArg w e)
   = do { (floats, e') <- makeTrivial mode NotTopLevel (fsLit "arg") e
-       ; let scaled_floats = scaleLetFloatsBy w floats
-       ; return (scaled_floats, ValArg w e') }
+       -- TODO: MattP looks like this should be propagated
+       ; return (floats, ValArg w e') }
 makeTrivialArg _ arg
   = return (emptyLetFloats, arg)  -- CastBy, TyArg
 
@@ -886,6 +880,7 @@ simplExprF1 env (App fun arg) cont
                                 , sc_cont    = cont } }
       _       ->
         -- MattP: TODO: This could be quite expensive.
+        -- TODO: arnaud: but not needed, will remove.
         let fun_ty = exprType fun
             (Weighted w _, _) = splitFunTy fun_ty
         in
@@ -2072,22 +2067,9 @@ trySeqRules in_env scrut rhs cont
                         , as_hole_ty = seq_id_ty }
                 , TyArg { as_arg_ty  = rhs_ty
                        , as_hole_ty  = piResultTy seq_id_ty scrut_ty }
-                , ValArg Omega no_cast_scrut]
-                -- The multiplicity of the scrutiny above is ω because the type
-                -- of seq requires that its first argument is unrestricted. The
-                -- typing rule of case also guarantees it though. In a more
-                -- general world, where the first argument of seq would have
-                -- affine multiplicity, then we could use the multiplicity of
-                -- the case (held in the case binder) instead.
+                , ValArg Omega no_cast_scrut] -- TODO: MattP: Check
     rule_cont = ApplyToVal { sc_dup = NoDup, sc_arg = rhs
                            , sc_env = in_env, sc_cont = cont, sc_weight = Omega}
-                           -- The multiplicity in sc_weight above is the
-                           -- multiplicity of the second argument of seq. Since
-                           -- seq's type, as it stands, imposes that its second
-                           -- argument be unrestricted, so is
-                           -- sc_weight. However, a more precise typing rule,
-                           -- for seq, would be to have it be linear. In which
-                           -- case, sc_weight should be 1.
     -- Lazily evaluated, so we don't do most of this
 
     drop_casts (Cast e _) = drop_casts e
@@ -3001,7 +2983,7 @@ mkDupableCont env (StrictBind { sc_bndr = bndr, sc_bndrs = bndrs
                              , sc_dup  = OkToDup
                              , sc_cont = mkBoringStop res_ty } ) }
 
-mkDupableCont env (StrictArg { sc_fun = info, sc_cci = cci, sc_cont = cont, sc_weight = weight })
+mkDupableCont env (StrictArg { sc_fun = info, sc_cci = cci, sc_cont = cont })
         -- See Note [Duplicating StrictArg]
         -- NB: sc_dup /= OkToDup; that is caught earlier by contIsDupable
   = do { (floats1, cont') <- mkDupableCont env cont
@@ -3012,7 +2994,7 @@ mkDupableCont env (StrictArg { sc_fun = info, sc_cci = cci, sc_cont = cont, sc_w
                             , sc_cci = cci
                             , sc_cont = cont'
                             , sc_dup = OkToDup
-                            , sc_weight = weight } ) }
+                            , sc_weight = Omega } ) } -- TODO: Arnaud: is this Omega correct? if so explain why.
 
 mkDupableCont env (ApplyToTy { sc_cont = cont
                              , sc_arg_ty = arg_ty, sc_hole_ty = hole_ty })
@@ -3020,8 +3002,8 @@ mkDupableCont env (ApplyToTy { sc_cont = cont
         ; return (floats, ApplyToTy { sc_cont = cont'
                                     , sc_arg_ty = arg_ty, sc_hole_ty = hole_ty }) }
 
-mkDupableCont env full_cont@(ApplyToVal { sc_arg = arg, sc_dup = dup
-                              , sc_env = se, sc_cont = cont, sc_weight = arg_mult })
+mkDupableCont env (ApplyToVal { sc_arg = arg, sc_dup = dup
+                              , sc_env = se, sc_cont = cont })
   =     -- e.g.         [...hole...] (...arg...)
         --      ==>
         --              let a = ...arg...
@@ -3031,8 +3013,7 @@ mkDupableCont env full_cont@(ApplyToVal { sc_arg = arg, sc_dup = dup
         ; let env' = env `setInScopeFromF` floats1
         ; (_, se', arg') <- simplArg env' dup se arg
         ; (let_floats2, arg'') <- makeTrivial (getMode env) NotTopLevel (fsLit "karg") arg'
-        ; let scaled_floats2 = scaleLetFloatsBy arg_mult let_floats2
-        ; let all_floats = floats1 `addLetFloats` scaled_floats2
+        ; let all_floats = floats1 `addLetFloats` let_floats2
         ; return ( all_floats
                  , ApplyToVal { sc_arg = arg''
                               , sc_env = se' `setInScopeFromF` all_floats
@@ -3040,7 +3021,7 @@ mkDupableCont env full_cont@(ApplyToVal { sc_arg = arg, sc_dup = dup
                                          -- arg'' in its in-scope set, even if makeTrivial
                                          -- has turned arg'' into a fresh variable
                                          -- See Note [StaticEnv invariant] in SimplUtils
-                              , sc_dup = OkToDup, sc_cont = cont', sc_weight = arg_mult }) }
+                              , sc_dup = OkToDup, sc_cont = cont', sc_weight = Omega }) }
 
 mkDupableCont env (Select { sc_bndr = case_bndr, sc_alts = alts
                           , sc_env = se, sc_cont = cont })
@@ -3552,4 +3533,3 @@ simplRules env mb_new_id rules mb_cont
                           , ru_fn    = fn_name'
                           , ru_args  = args'
                           , ru_rhs   = rhs' }) }
-

--- a/compiler/specialise/SpecConstr.hs
+++ b/compiler/specialise/SpecConstr.hs
@@ -2263,7 +2263,7 @@ argToPat _env _in_scope _val_env arg _arg_occ
 wildCardPat :: Type -> UniqSM (Bool, CoreArg)
 wildCardPat ty
   = do { uniq <- getUniqueM
-       ; let id = mkSysLocalOrCoVar (fsLit "sc") uniq Omega ty
+       ; let id = mkSysLocalOrCoVar (fsLit "sc") uniq (Regular Omega) ty
        ; return (False, varToCoreExpr id) }
 
 argsToPats :: ScEnv -> InScopeSet -> ValueEnv

--- a/compiler/stranal/WwLib.hs
+++ b/compiler/stranal/WwLib.hs
@@ -455,7 +455,7 @@ applyToVars vars fn = mkVarApps fn vars
 
 mk_wrap_arg :: Unique -> Weighted Type -> Demand -> Id
 mk_wrap_arg uniq (Weighted w ty) dmd
-  = mkSysLocalOrCoVar (fsLit "w") uniq w ty
+  = mkSysLocalOrCoVar (fsLit "w") uniq (Regular w) ty
        `setIdDemandInfo` dmd
 
 {- Note [Freshen WW arguments]
@@ -1005,4 +1005,4 @@ mk_ww_local :: Unique -> (Weighted Type, StrictnessMark) -> Id
 -- See Note [Record evaluated-ness in worker/wrapper]
 mk_ww_local uniq (Weighted w ty,str)
   = setCaseBndrEvald str $
-    mkSysLocalOrCoVar (fsLit "ww") uniq w ty
+    mkSysLocalOrCoVar (fsLit "ww") uniq (Regular w) ty

--- a/compiler/typecheck/TcRnMonad.hs
+++ b/compiler/typecheck/TcRnMonad.hs
@@ -648,12 +648,12 @@ newSysName occ
 newSysLocalId :: FastString -> Rig -> TcType -> TcRnIf gbl lcl TcId
 newSysLocalId fs w ty
   = do  { u <- newUnique
-        ; return (mkSysLocalOrCoVar fs u w ty) }
+        ; return (mkSysLocalOrCoVar fs u (Regular w) ty) }
 
 newSysLocalIds :: FastString -> [Weighted TcType] -> TcRnIf gbl lcl [TcId]
 newSysLocalIds fs tys
   = do  { us <- newUniqueSupply
-        ; let mkId' n (Weighted w t) = mkSysLocalOrCoVar fs n w t
+        ; let mkId' n (Weighted w t) = mkSysLocalOrCoVar fs n (Regular w) t
         ; return (zipWith mkId' (uniqsFromSupply us) tys) }
 
 instance MonadUnique (IOEnv (Env gbl lcl)) where

--- a/compiler/types/TyCoRep.hs
+++ b/compiler/types/TyCoRep.hs
@@ -170,7 +170,6 @@ import VarEnv
 import VarSet
 import Name hiding ( varName )
 import Weight
-import {-# SOURCE #-}UsageEnv
 import TyCon
 import Class
 import CoAxiom

--- a/compiler/vectorise/Vectorise/Builtins/Initialise.hs
+++ b/compiler/vectorise/Vectorise/Builtins/Initialise.hs
@@ -118,7 +118,7 @@ initBuiltins
             selElementss  = array     ((2, 0), (mAX_DPH_SUM, mAX_DPH_SUM)) sel_elements
 
           -- Distinct local variable
-      ; liftingContext  <- liftM (\u -> mkSysLocalOrCoVar (fsLit "lc") u Omega intPrimTy) newUnique
+      ; liftingContext  <- liftM (\u -> mkSysLocalOrCoVar (fsLit "lc") u (Regular Omega) intPrimTy) newUnique
 
       ; return $ Builtins
                { parrayTyCon          = parrayTyCon

--- a/compiler/vectorise/Vectorise/Monad/Naming.hs
+++ b/compiler/vectorise/Vectorise/Monad/Naming.hs
@@ -107,7 +107,7 @@ newExportedVar occ_name ty
 newLocalVar :: FastString -> Type -> VM Var
 newLocalVar fs ty
  = do u <- liftDs newUnique
-      return $ mkSysLocalOrCoVar fs u Omega ty
+      return $ mkSysLocalOrCoVar fs u (Regular Omega) ty
 
 -- |Make several fresh local variables with the given types.
 -- The variable's names are formed using the given string as the prefix.


### PR DESCRIPTION
This PR reverts the changes which the alias-like binders of #128 have rendered obsolete.

This is not a pure revert, but should be close enough.