### PR TITLE
Activate linter in the CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,8 @@ aliases:
         ifneq "\$(BuildFlavour)" ""
         include mk/flavours/\$(BuildFlavour).mk
         endif
+        GhcLibHcOpts       = -O -dcore-lint
+        # TODO: arnaud: revert the above line before merge (hack)
         EOF
   - &configure_unix
     run:


### PR DESCRIPTION
I'm not too sure about this. It may have a significant cost in compilation time, which would be unfortunate.

But preserving the linter is really important for this PR. So I hacked something. It's really ugly too, but takes the advantage that the CI configuration is already heavily tweaked.

An alternative is to have two jobs in CI, one building the test, the other using `-dcore-lint` on the libraries.

At any rates, local tests suggest that the build passes the linter (!), but I'd like the CI to check from a clean state for me every time.

Green will close #122 .