### PR TITLE
Type-class constructors have no wrappers

### DIFF
--- a/compiler/basicTypes/MkId.hs
+++ b/compiler/basicTypes/MkId.hs
@@ -600,9 +600,9 @@ mkDataConRepX :: Monad m =>
              -> m DataConRep
 mkDataConRepX mkArgs mkBody fam_envs wrap_name mb_bangs data_con
 -- See Note [All data constructors have wrappers]
---  | not wrapper_reqd
---  = return NoDataConRep
--- TODO: arnaud: clean this up
+-- TODO: arnaud: ^ update this
+ | not wrapper_reqd
+ = return NoDataConRep
 
   | otherwise
   = do { wrap_args <- mkArgs wrap_arg_tys
@@ -694,19 +694,7 @@ mkDataConRepX mkArgs mkBody fam_envs wrap_name mb_bangs data_con
     (rep_tys, rep_strs) = unzip (concat rep_tys_w_strs)
 
     wrapper_reqd =
-        (not (isNewTyCon tycon)
-                     -- (Most) newtypes have only a worker, with the exception
-                     -- of some newtypes written with GADT syntax. See below.
-         && (any isBanged (ev_ibangs ++ arg_ibangs)
-                     -- Some forcing/unboxing (includes eq_spec)
-             || (not $ null eq_spec))) -- GADT
-      || isFamInstTyCon tycon -- Cast result
-      || dataConUserTyVarsArePermuted data_con
-                     -- If the data type was written with GADT syntax and
-                     -- orders the type variables differently from what the
-                     -- worker expects, it needs a data con wrapper to reorder
-                     -- the type variables.
-                     -- See Note [Data con wrappers and GADT syntax].
+      not (isClassTyCon tycon)
 
     initial_wrap_app = Var (dataConWorkId data_con)
                        `mkTyApps`  res_ty_args

--- a/compiler/deSugar/Desugar.hs
+++ b/compiler/deSugar/Desugar.hs
@@ -476,7 +476,7 @@ unfold_coerce bndrs lhs rhs = do
                 v'  = mkLocalCoVar
                         (mkDerivedInternalName mkRepEqOcc u (getName v)) ty'
                 box = Var (dataConWrapId coercibleDataCon) `mkTyApps`
-                      [omegaDataConTy, k, t1, t2] `App`
+                      [k, t1, t2] `App`
                       Coercion (mkCoVarCo v')
 
             (bndrs, wrap) <- go vs

--- a/compiler/iface/IfaceSyn.hs
+++ b/compiler/iface/IfaceSyn.hs
@@ -423,7 +423,7 @@ ifaceDeclImplicitBndrs (IfaceClass { ifName = cls_tc_name
     --    data constructor (DataCon namespace)
     --    data worker (Id namespace)
     --    no wrapper (class dictionaries never have a wrapper)
-    [dc_occ, dcww_occ, dcwrap_occ] ++
+    [dc_occ, dcww_occ] ++
     -- associated types
     [occName (ifName at) | IfaceAT at _ <- ats ] ++
     -- superclass selectors
@@ -437,7 +437,6 @@ ifaceDeclImplicitBndrs (IfaceClass { ifName = cls_tc_name
     co_occs | is_newtype = [mkNewTyCoOcc cls_tc_occ]
             | otherwise  = []
     dcww_occ = mkDataConWorkerOcc dc_occ
-    dcwrap_occ = mkDataConWrapperOcc dc_occ
     dc_occ = mkClassDataConOcc cls_tc_occ
     is_newtype = n_sigs + n_ctxt == 1 -- Sigh (keep this synced with buildClass)
 

--- a/compiler/simplCore/Simplify.hs
+++ b/compiler/simplCore/Simplify.hs
@@ -855,8 +855,8 @@ simplExprF env e cont
 simplExprF1 :: SimplEnv -> InExpr -> SimplCont
             -> SimplM (SimplFloats, OutExpr)
 
-simplExprF1 _ (Type ty) _
-  = pprPanic "simplExprF: type" (ppr ty)
+simplExprF1 _ (Type ty) cont
+  = pprPanic "simplExprF: type" (ppr ty <+> text"cont: " <+> ppr cont)
     -- simplExprF does only with term-valued expressions
     -- The (Type ty) case is handled separately by simplExpr
     -- and by the other callers of simplExprF

--- a/compiler/typecheck/ClsInst.hs
+++ b/compiler/typecheck/ClsInst.hs
@@ -182,7 +182,7 @@ matchCTuple clas tys   -- (isCTupleClass clas) holds
             -- The dfun *is* the data constructor!
   where
      data_con = tyConSingleDataCon (classTyCon clas)
-     tuple_ev = evDFunApp (dataConWrapId data_con) (omegaDataConTy : tys)
+     tuple_ev = evDFunApp (dataConWrapId data_con) tys
 
 {- ********************************************************************
 *                                                                     *
@@ -453,7 +453,7 @@ if you'd written
 matchLiftedEquality :: [Type] -> TcM ClsInstResult
 matchLiftedEquality args
   = return (OneInst { cir_new_theta = [ mkTyConApp eqPrimTyCon args ]
-                    , cir_mk_ev     = evDFunApp (dataConWrapId heqDataCon) (omegaDataConTy : args)
+                    , cir_mk_ev     = evDFunApp (dataConWrapId heqDataCon) args
                     , cir_what      = BuiltinInstance })
 
 -- See also Note [The equality types story] in TysPrim
@@ -461,7 +461,7 @@ matchLiftedCoercible :: [Type] -> TcM ClsInstResult
 matchLiftedCoercible args@[k, t1, t2]
   = return (OneInst { cir_new_theta = [ mkTyConApp eqReprPrimTyCon args' ]
                     , cir_mk_ev     = evDFunApp (dataConWrapId coercibleDataCon)
-                                                (omegaDataConTy : args)
+                                                args
                     , cir_what      = BuiltinInstance })
   where
     args' = [k, k, t1, t2]

--- a/compiler/typecheck/Inst.hs
+++ b/compiler/typecheck/Inst.hs
@@ -365,7 +365,7 @@ instCallConstraints orig preds
      | Just (tc, args@[_, _, ty1, ty2]) <- splitTyConApp_maybe pred
      , tc `hasKey` heqTyConKey
      = do { co <- unifyType Nothing ty1 ty2
-          ; return (evDFunApp (dataConWrapId heqDataCon) (omegaDataConTy : args) [Coercion co]) }
+          ; return (evDFunApp (dataConWrapId heqDataCon) args [Coercion co]) }
 
      | otherwise
      = emitWanted orig pred

--- a/compiler/typecheck/TcInstDcls.hs
+++ b/compiler/typecheck/TcInstDcls.hs
@@ -839,7 +839,7 @@ tcInstDecl2 (InstInfo { iSpec = ispec, iBinds = ibinds })
                      --    con_app_tys  = MkD ty1 ty2
                      --    con_app_scs  = MkD ty1 ty2 sc1 sc2
                      --    con_app_args = MkD ty1 ty2 sc1 sc2 op1 op2
-             con_app_tys  = mkHsWrap (mkWpTyApps (omegaDataConTy : inst_tys))
+             con_app_tys  = mkHsWrap (mkWpTyApps inst_tys)
                                   (HsConLikeOut noExt (RealDataCon dict_constr))
                        -- NB: We *can* have covars in inst_tys, in the case of
                        -- promoted GADT constructors.


### PR DESCRIPTION
This is quite a bit more simpler, the constructors are never
manipulate by the user anyway, and it avoids having to track all the
the places where dictionaries are instantiated and insert the
appropriate multiplicity arguments throughout the code.