### PR TITLE
Unrestricted values in primitive data types

### DIFF
--- a/libraries/base/GHC/Base.hs
+++ b/libraries/base/GHC/Base.hs
@@ -86,6 +86,8 @@ Other Prelude modules are much easier with fewer complex dependencies.
            , KindSignatures
            , PolyKinds
            , DataKinds
+           , LinearTypes
+           , GADTSyntax
   #-}
 -- -Wno-orphans is needed for things like:
 -- Orphan rule: "x# -# x#" ALWAYS forall x# :: Int# -# x# x# = 0
@@ -195,9 +197,15 @@ Similar to GHC.Integer.
 -- for use when compiling GHC.Base itself doesn't work
 data  Bool  =  False | True
 data Ordering = LT | EQ | GT
-data Char = C# Char#
+-- Char is defined with GADT syntax to make the data constructor unrestricted
+-- in its argument for users of linear haskell.
+data Char where
+  C# :: Char# -> Char
 type  String = [Char]
-data Int = I# Int#
+-- Int is defined with GADT syntax to make the data constructor unrestricted
+-- in its argument for users of linear haskell.
+data Int where
+  I# :: Int# -> Int
 data  ()  =  ()
 data [] a = MkNil
 

--- a/libraries/base/GHC/Int.hs
+++ b/libraries/base/GHC/Int.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE Trustworthy #-}
 {-# LANGUAGE CPP, NoImplicitPrelude, BangPatterns, MagicHash, UnboxedTuples,
-             StandaloneDeriving, NegativeLiterals #-}
+             StandaloneDeriving, NegativeLiterals, LinearTypes, GADTSyntax #-}
 {-# OPTIONS_HADDOCK hide #-}
 
 -----------------------------------------------------------------------------
@@ -53,8 +53,11 @@ import GHC.Show
 
 -- Int8 is represented in the same way as Int. Operations may assume
 -- and must ensure that it holds only values from its logical range.
+-- It uses GADT syntax to be unrestricted in the underlying Int# for
+-- users of linear haskell.
 
-data {-# CTYPE "HsInt8" #-} Int8 = I8# Int#
+data {-# CTYPE "HsInt8" #-} Int8 where
+  I8# :: Int# -> Int8
 -- ^ 8-bit signed integer type
 
 -- See GHC.Classes#matching_overloaded_methods_in_rules
@@ -253,8 +256,11 @@ instance FiniteBits Int8 where
 
 -- Int16 is represented in the same way as Int. Operations may assume
 -- and must ensure that it holds only values from its logical range.
+-- It uses GADT syntax to be unrestricted in the underlying Int# for
+-- users of linear haskell.
 
-data {-# CTYPE "HsInt16" #-} Int16 = I16# Int#
+data {-# CTYPE "HsInt16" #-} Int16 where
+  I16# :: Int# -> Int16
 -- ^ 16-bit signed integer type
 
 -- See GHC.Classes#matching_overloaded_methods_in_rules
@@ -457,9 +463,12 @@ instance FiniteBits Int16 where
 #if WORD_SIZE_IN_BITS > 32
 -- Operations may assume and must ensure that it holds only values
 -- from its logical range.
+-- It uses GADT syntax to be unrestricted in the underlying Int# for
+-- users of linear haskell.
 #endif
 
-data {-# CTYPE "HsInt32" #-} Int32 = I32# Int#
+data {-# CTYPE "HsInt32" #-} Int32 where
+  I32# :: Int# -> Int32
 -- ^ 32-bit signed integer type
 
 -- See GHC.Classes#matching_overloaded_methods_in_rules
@@ -675,7 +684,10 @@ instance Ix Int32 where
 
 #if WORD_SIZE_IN_BITS < 64
 
-data {-# CTYPE "HsInt64" #-} Int64 = I64# Int64#
+-- The Int64 data type uses GADT syntax to be unrestricted in the underlying
+-- Int64# for users of linear haskell.
+data {-# CTYPE "HsInt64" #-} Int64 where
+  I64# :: Int64# -> Int64
 -- ^ 64-bit signed integer type
 
 -- See GHC.Classes#matching_overloaded_methods_in_rules
@@ -874,8 +886,11 @@ a `iShiftRA64#` b | isTrue# (b >=# 64#) = if isTrue# (a `ltInt64#` (intToInt64# 
 -- Int64 is represented in the same way as Int.
 -- Operations may assume and must ensure that it holds only values
 -- from its logical range.
+-- It uses GADT syntax to be unrestricted in the underlying Int# for
+-- users of linear haskell.
 
-data {-# CTYPE "HsInt64" #-} Int64 = I64# Int#
+data {-# CTYPE "HsInt64" #-} Int64 where
+  I64# :: Int# -> Int64
 -- ^ 64-bit signed integer type
 
 -- See GHC.Classes#matching_overloaded_methods_in_rules

--- a/libraries/base/GHC/Ptr.hs
+++ b/libraries/base/GHC/Ptr.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE Unsafe #-}
-{-# LANGUAGE CPP, NoImplicitPrelude, MagicHash, RoleAnnotations #-}
+{-# LANGUAGE CPP, NoImplicitPrelude, MagicHash, RoleAnnotations, GADTSyntax, LinearTypes #-}
 {-# OPTIONS_HADDOCK hide #-}
 
 -----------------------------------------------------------------------------
@@ -41,8 +41,13 @@ import Numeric          ( showHex )
 -- pointer. And phantom is useful to implement castPtr (see #9163)
 
 -- redundant role annotation checks that this doesn't change
+
+-- The Ptr data type is defined with GADT syntax so that the data constructor
+-- is unrestricted in the Addr# argument. This is desirable for users
+-- of linear haskell.
 type role Ptr phantom
-data Ptr a = Ptr Addr#
+data Ptr a where
+  Ptr :: Addr# -> Ptr a
   deriving ( Eq  -- ^ @since 2.01
            , Ord -- ^ @since 2.01
            )

--- a/libraries/base/GHC/Word.hs
+++ b/libraries/base/GHC/Word.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE Trustworthy #-}
-{-# LANGUAGE CPP, NoImplicitPrelude, BangPatterns, MagicHash, UnboxedTuples #-}
+{-# LANGUAGE CPP, NoImplicitPrelude, BangPatterns, MagicHash, UnboxedTuples,
+             LinearTypes, GADTSyntax #-}
 {-# OPTIONS_HADDOCK hide #-}
 
 -----------------------------------------------------------------------------
@@ -60,8 +61,11 @@ import GHC.Show
 
 -- Word8 is represented in the same way as Word. Operations may assume
 -- and must ensure that it holds only values from its logical range.
+-- It uses GADT syntax to be unrestricted in the underlying Word# for
+-- users of linear haskell.
 
-data {-# CTYPE "HsWord8" #-} Word8 = W8# Word#
+data {-# CTYPE "HsWord8" #-} Word8 where
+  W8# :: Word# -> Word8
 -- ^ 8-bit unsigned integer type
 
 -- See GHC.Classes#matching_overloaded_methods_in_rules
@@ -244,8 +248,11 @@ instance FiniteBits Word8 where
 
 -- Word16 is represented in the same way as Word. Operations may assume
 -- and must ensure that it holds only values from its logical range.
+-- It uses GADT syntax to be unrestricted in the underlying Word# for
+-- users of linear haskell.
 
-data {-# CTYPE "HsWord16" #-} Word16 = W16# Word#
+data {-# CTYPE "HsWord16" #-} Word16 where
+  W16# :: Word# -> Word16
 -- ^ 16-bit unsigned integer type
 
 -- See GHC.Classes#matching_overloaded_methods_in_rules
@@ -437,6 +444,8 @@ byteSwap16 (W16# w#) = W16# (narrow16Word# (byteSwap16# w#))
 #if WORD_SIZE_IN_BITS > 32
 -- Operations may assume and must ensure that it holds only values
 -- from its logical range.
+-- It uses GADT syntax to be unrestricted in the underlying Word# for
+-- users of linear haskell.
 
 -- We can use rewrite rules for the RealFrac methods
 
@@ -472,7 +481,8 @@ byteSwap16 (W16# w#) = W16# (narrow16Word# (byteSwap16# w#))
 
 #endif
 
-data {-# CTYPE "HsWord32" #-} Word32 = W32# Word#
+data {-# CTYPE "HsWord32" #-} Word32 where
+  W32# :: Word# -> Word32
 -- ^ 32-bit unsigned integer type
 
 -- See GHC.Classes#matching_overloaded_methods_in_rules
@@ -660,7 +670,10 @@ byteSwap32 (W32# w#) = W32# (narrow32Word# (byteSwap32# w#))
 
 #if WORD_SIZE_IN_BITS < 64
 
-data {-# CTYPE "HsWord64" #-} Word64 = W64# Word64#
+-- The Word64 data type uses GADT syntax to be unrestricted in the underlying
+-- Word64# for users of linear haskell.
+data {-# CTYPE "HsWord64" #-} Word64 where
+  W64# :: Word64# -> Word64
 -- ^ 64-bit unsigned integer type
 
 -- See GHC.Classes#matching_overloaded_methods_in_rules
@@ -801,8 +814,11 @@ a `shiftRL64#` b | isTrue# (b >=# 64#) = wordToWord64# 0##
 -- Word64 is represented in the same way as Word.
 -- Operations may assume and must ensure that it holds only values
 -- from its logical range.
+-- It uses GADT syntax to be unrestricted in the underlying Word# for
+-- users of linear haskell.
 
-data {-# CTYPE "HsWord64" #-} Word64 = W64# Word#
+data {-# CTYPE "HsWord64" #-} Word64 where
+  W64# :: Word# -> Word64
 -- ^ 64-bit unsigned integer type
 
 -- See GHC.Classes#matching_overloaded_methods_in_rules

--- a/libraries/ghc-prim/GHC/Types.hs
+++ b/libraries/ghc-prim/GHC/Types.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE MagicHash, NoImplicitPrelude, TypeFamilies, UnboxedTuples,
              MultiParamTypeClasses, RoleAnnotations, CPP, TypeOperators,
-             PolyKinds #-}
+             PolyKinds, LinearTypes, GADTSyntax #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  GHC.Types
@@ -129,25 +129,40 @@ To convert a 'Char' to or from the corresponding 'Int' value defined
 by Unicode, use 'Prelude.toEnum' and 'Prelude.fromEnum' from the
 'Prelude.Enum' class respectively (or equivalently 'ord' and 'chr').
 -}
-data {-# CTYPE "HsChar" #-} Char = C# Char#
+data {-# CTYPE "HsChar" #-} Char where
+  -- Char is defined with GADT syntax to make the data constructor unrestricted
+  -- in its argument for users of linear haskell.
+  C# :: Char# -> Char
 
 -- | A fixed-precision integer type with at least the range @[-2^29 .. 2^29-1]@.
 -- The exact range for a given implementation can be determined by using
 -- 'Prelude.minBound' and 'Prelude.maxBound' from the 'Prelude.Bounded' class.
-data {-# CTYPE "HsInt" #-} Int = I# Int#
+data {-# CTYPE "HsInt" #-} Int where
+  -- Int is defined with GADT syntax to make the data constructor unrestricted
+  -- in its argument for users of linear haskell.
+  I# :: Int# -> Int
 
 -- |A 'Word' is an unsigned integral type, with the same size as 'Int'.
-data {-# CTYPE "HsWord" #-} Word = W# Word#
+data {-# CTYPE "HsWord" #-} Word where
+  -- Word is defined with GADT syntax to make the data constructor unrestricted
+  -- in its argument for users of linear haskell.
+  W# :: Word# -> Word
 
 -- | Single-precision floating point numbers.
 -- It is desirable that this type be at least equal in range and precision
 -- to the IEEE single-precision type.
-data {-# CTYPE "HsFloat" #-} Float = F# Float#
+data {-# CTYPE "HsFloat" #-} Float where
+  -- Float is defined with GADT syntax to make the data constructor unrestricted
+  -- in its argument for users of linear haskell.
+  F# :: Float# -> Float
 
 -- | Double-precision floating point numbers.
 -- It is desirable that this type be at least equal in range and precision
 -- to the IEEE double-precision type.
-data {-# CTYPE "HsDouble" #-} Double = D# Double#
+data {-# CTYPE "HsDouble" #-} Double where
+  -- Double is defined with GADT syntax to make the data constructor unrestricted
+  -- in its argument for users of linear haskell.
+  D# :: Double# -> Double
 
 
 {- *********************************************************************


### PR DESCRIPTION
Make the data types Double, Float, Char, Ptr, Int{N}, and Word{N} be unrestricted in the unboxed argument in their data constructor. This is related to the discussion in https://github.com/tweag/ghc/issues/179.