### PR TITLE
Hide multiplicities when printing constructors

### DIFF
--- a/compiler/iface/IfaceSyn.hs
+++ b/compiler/iface/IfaceSyn.hs
@@ -69,7 +69,6 @@ import TyCon ( Role (..), Injectivity(..) )
 import Util( dropList, filterByList )
 import DataCon (SrcStrictness(..), SrcUnpackedness(..))
 import Lexeme (isLexSym)
-import FastString
 
 import Control.Monad
 import System.IO.Unsafe
@@ -883,9 +882,7 @@ pprIfaceDecl _ (IfacePatSyn { ifName = name,
                              , ppWhen insert_empty_ctxt $ parens empty <+> darrow
                              , ex_msg
                              , pprIfaceContextArr prov_ctxt
-                             , pprIfaceType $ foldr
-                                                (IfaceFunTy (IfaceTyConApp omega_ty IA_Nil))
-                                                pat_ty arg_tys ])
+                             , pprIfaceType $ foldr (IfaceFunTy omega_ty) pat_ty arg_tys ])
       where
         univ_msg = pprUserIfaceForAll univ_bndrs
         ex_msg   = pprUserIfaceForAll ex_bndrs

--- a/compiler/iface/IfaceType.hs
+++ b/compiler/iface/IfaceType.hs
@@ -78,6 +78,7 @@ import Util
 
 import Data.Maybe( isJust )
 import qualified Data.Semigroup as Semi
+import qualified GHC.LanguageExtensions as LangExt
 
 {-
 ************************************************************************
@@ -861,6 +862,8 @@ For this reason it was decided that we would hide RuntimeRep variables for now
 (see #11549). We do this by defaulting all type variables of kind RuntimeRep to
 LiftedRep. This is done in a pass right before pretty-printing
 (defaultRuntimeRepVars, controlled by -fprint-explicit-runtime-reps)
+The same is done with multiplicities (defaultMultiplicityVars, controlled
+by -XLinearTypes)
 -}
 
 -- | Default 'RuntimeRep' variables to 'LiftedPtr'. e.g.
@@ -978,7 +981,7 @@ defaultMultiplicityVars sty = go emptyFsEnv
 
     go _ ty@(IfaceFreeTyVar tv)
       | userStyle sty && TyCoRep.isMultiplicityTy (tyVarKind tv)
-         -- don't require -fprint-explicit-runtime-reps for good debugging output
+         -- don't require -XLinearTypes for good debugging output
       = IfaceTyConApp omega_ty IA_Nil
       | otherwise
       = ty
@@ -1035,7 +1038,7 @@ eliminateMultiplicity :: (IfaceType -> SDoc) -> IfaceType -> SDoc
 eliminateMultiplicity f ty = sdocWithDynFlags $ \dflags ->
     -- For the time being, printing multiplicities piggybacks on the
     -- print-explicit-runtime-reps flag. But will eventually get its own flag.
-    if gopt Opt_PrintExplicitRuntimeReps dflags
+    if xopt LangExt.LinearTypes dflags
       then f ty
       else getPprStyle $ \sty -> f (defaultMultiplicityVars sty ty)
 

--- a/compiler/iface/IfaceType.hs
+++ b/compiler/iface/IfaceType.hs
@@ -770,10 +770,11 @@ pprIfaceType       = pprPrecIfaceType topPrec
 pprParendIfaceType = pprPrecIfaceType appPrec
 
 pprPrecIfaceType :: PprPrec -> IfaceType -> SDoc
--- We still need `eliminateRuntimeRep`, since the `pprPrecIfaceType` maybe
--- called from other places, besides `:type` and `:info`.
+-- We still need `eliminateRuntimeRep` and `eliminateMultiplicity`
+-- since the `pprPrecIfaceType` may be called from other places, besides
+-- `:type` and `:info`.
 pprPrecIfaceType prec ty =
-  eliminateRuntimeRep (\ty -> eliminateMultiplicity (ppr_ty prec) ty) ty
+  eliminateRuntimeRep (eliminateMultiplicity (ppr_ty prec)) ty
 
 ppr_ty :: PprPrec -> IfaceType -> SDoc
 ppr_ty _         (IfaceFreeTyVar tyvar) = ppr tyvar  -- This is the main reason for IfaceFreeTyVar!
@@ -1143,7 +1144,7 @@ data ShowForAllFlag = ShowForAllMust | ShowForAllWhen
 
 pprIfaceSigmaType :: ShowForAllFlag -> IfaceType -> SDoc
 pprIfaceSigmaType show_forall ty
-  = eliminateRuntimeRep ppr_fn ty
+  = eliminateRuntimeRep (eliminateMultiplicity ppr_fn) ty
   where
     ppr_fn iface_ty =
       let (tvs, theta, tau) = splitIfaceSigmaTy iface_ty

--- a/testsuite/tests/ghci/scripts/all.T
+++ b/testsuite/tests/ghci/scripts/all.T
@@ -59,7 +59,7 @@ test('T9367',
      [req_interp, when(fast() or config.os != 'mingw32', skip)],
      run_command,
      ['$MAKE -s --no-print-directory T9367'])
-test('ghci025', [extra_files(['Ghci025B.hs', 'Ghci025C.hs', 'Ghci025D.hs']), expect_broken(239)], ghci_script, ['ghci025.script'])
+test('ghci025', extra_files(['Ghci025B.hs', 'Ghci025C.hs', 'Ghci025D.hs']), ghci_script, ['ghci025.script'])
 test('ghci026', extra_files(['../prog002']), ghci_script, ['ghci026.script'])
 
 test('ghci027', [], ghci_script, ['ghci027.script'])
@@ -252,7 +252,7 @@ test('T11376', normal, ghci_script, ['T11376.script'])
 test('T12007', normal, ghci_script, ['T12007.script'])
 test('T11975', normal, ghci_script, ['T11975.script'])
 test('T10963', normal, ghci_script, ['T10963.script'])
-test('T11721', expect_broken(239), ghci_script, ['T11721.script'])
+test('T11721', normal, ghci_script, ['T11721.script'])
 test('T12005', normal, ghci_script, ['T12005.script'])
 test('T12023', normal, run_command,
                ['$MAKE -s --no-print-directory T12023'])
@@ -274,7 +274,7 @@ test('T13466', normal, ghci_script, ['T13466.script'])
 test('GhciCurDir', normal, ghci_script, ['GhciCurDir.script'])
 test('T13591', expect_broken(13591), ghci_script, ['T13591.script'])
 test('T13699', normal, ghci_script, ['T13699.script'])
-test('T13988', expect_broken(239), ghci_script, ['T13988.script'])
+test('T13988', normal, ghci_script, ['T13988.script'])
 test('T13407', normal, ghci_script, ['T13407.script'])
 test('T13963', normal, ghci_script, ['T13963.script'])
 test('T14342', [extra_hc_opts("-XOverloadedStrings -XRebindableSyntax")],

--- a/testsuite/tests/linear/should_run/LinearGhci.script
+++ b/testsuite/tests/linear/should_run/LinearGhci.script
@@ -1,0 +1,4 @@
+data T a = MkT a
+:type +v MkT
+:set -XLinearTypes
+:type +v MkT

--- a/testsuite/tests/linear/should_run/LinearGhci.stdout
+++ b/testsuite/tests/linear/should_run/LinearGhci.stdout
@@ -1,0 +1,2 @@
+MkT :: a -> T a
+MkT :: a -->.(n) T a

--- a/testsuite/tests/linear/should_run/Makefile
+++ b/testsuite/tests/linear/should_run/Makefile
@@ -1,0 +1,3 @@
+TOP=../../..
+include $(TOP)/mk/boilerplate.mk
+include $(TOP)/mk/test.mk

--- a/testsuite/tests/linear/should_run/all.T
+++ b/testsuite/tests/linear/should_run/all.T
@@ -1,1 +1,2 @@
 test('LinearTypeable', normal, compile_and_run, [''])
+test('LinearGhci', normal, ghci_script, ['LinearGhci.script'])


### PR DESCRIPTION
Refs #239

TODO: 

- [x] consider combining `eliminateRuntimeRep` and `eliminateMultiplicity`, perhaps defaulting
- [x] add a test