### PR TITLE
Add missing tidying in tidySigSkol

### DIFF
--- a/compiler/typecheck/TcMType.hs
+++ b/compiler/typecheck/TcMType.hs
@@ -2146,9 +2146,16 @@ tidySigSkol env cx ty tv_prs
         (env', tv') = tidy_tv_bndr env tv
 
     tidy_ty env (FunTy w arg res)
-      = FunTy w (tidyType env arg) (tidy_ty env res)
+      = FunTy (tidyMult env w) (tidyType env arg) (tidy_ty env res)
 
     tidy_ty env ty = tidyType env ty
+
+    tidyMult _   Zero = Zero
+    tidyMult _   One = One
+    tidyMult _   Omega = Omega
+    tidyMult env (MultThing ty) = MultThing (tidy_ty env ty)
+    tidyMult env (MultAdd x y) = MultAdd (tidyMult env x) (tidyMult env y)
+    tidyMult env (MultMul x y) = MultMul (tidyMult env x) (tidyMult env y)
 
     tidy_tv_bndr :: TidyEnv -> TyCoVar -> (TidyEnv, TyCoVar)
     tidy_tv_bndr env@(occ_env, subst) tv

--- a/testsuite/tests/polykinds/T9222.stderr
+++ b/testsuite/tests/polykinds/T9222.stderr
@@ -9,7 +9,7 @@ T9222.hs:14:3: error:
       ‘c’ is a rigid type variable bound by
         the type of the constructor ‘Want’:
           forall i1 j1 (a :: (i1, j1)) (b :: i1) (c :: j1).
-          ((a ~ '(b, c)) => Proxy b) -->.(n) Want a
+          ((a ~ '(b, c)) => Proxy b) -> Want a
         at T9222.hs:14:3-43
     • In the ambiguity check for ‘Want’
       To defer the ambiguity check to use sites, enable AllowAmbiguousTypes


### PR DESCRIPTION
This addresses both parts of #176:
* If linearity is disabled, the type no longer shows the linearity arrow.
* If we print linear types (by changing `do_multiplicity = False` in `hideNonStandardTypes`), then before the fix we had two different variables `n1` and `n`; after the fix, there's a single variable `n`.