### PR TITLE
Multiplicity addition and multiplication families

### DIFF
--- a/compiler/prelude/PrelNames.hs
+++ b/compiler/prelude/PrelNames.hs
@@ -1918,6 +1918,12 @@ multiplicityTyConKey = mkPreludeTyConUnique 191
 unrestrictedFunTyConKey :: Unique
 unrestrictedFunTyConKey = mkPreludeTyConUnique 192
 
+multAddTyConKey :: Unique
+multAddTyConKey = mkPreludeTyConUnique 193
+
+multMulTyConKey :: Unique
+multMulTyConKey = mkPreludeTyConUnique 194
+
 ---------------- Template Haskell -------------------
 --      THNames.hs: USES TyConUniques 200-299
 -----------------------------------------------------

--- a/compiler/prelude/TysWiredIn.hs
+++ b/compiler/prelude/TysWiredIn.hs
@@ -125,6 +125,7 @@ module TysWiredIn (
         multiplicityTyConName, oneDataConName, omegaDataConName, multiplicityTy,
         multiplicityTyCon, oneDataCon, omegaDataCon, oneDataConTy, omegaDataConTy,
         oneDataConTyCon, omegaDataConTyCon,
+        multAddTyCon, multMulTyCon,
 
         unrestrictedFunTyCon, unrestrictedFunTyConName
 
@@ -1182,6 +1183,27 @@ omegaDataConTy = mkTyConTy omegaDataConTyCon
 oneDataConTyCon, omegaDataConTyCon :: TyCon
 oneDataConTyCon = promoteDataCon oneDataCon
 omegaDataConTyCon = promoteDataCon omegaDataCon
+
+multAddTyConName, multMulTyConName :: Name
+multAddTyConName =
+    mkWiredInTyConName UserSyntax gHC_TYPES (fsLit "MultAdd") multAddTyConKey multAddTyCon
+multMulTyConName =
+    mkWiredInTyConName UserSyntax gHC_TYPES (fsLit "MultMul") multMulTyConKey multMulTyCon
+
+multAddTyCon, multMulTyCon :: TyCon
+multAddTyCon = mkFamilyTyCon multAddTyConName binders multiplicityTy Nothing
+                         (BuiltInSynFamTyCon trivialBuiltInFamily)
+                         Nothing
+                         NotInjective
+  where
+    binders = mkTemplateAnonTyConBinders [multiplicityTy, multiplicityTy]
+
+multMulTyCon = mkFamilyTyCon multMulTyConName binders multiplicityTy Nothing
+                         (BuiltInSynFamTyCon trivialBuiltInFamily)
+                         Nothing
+                         NotInjective
+  where
+    binders = mkTemplateAnonTyConBinders [multiplicityTy, multiplicityTy]
 
 unrestrictedFunTy :: Type
 unrestrictedFunTy = functionWithMultiplicity omegaDataConTy

--- a/compiler/prelude/TysWiredIn.hs-boot
+++ b/compiler/prelude/TysWiredIn.hs-boot
@@ -48,3 +48,4 @@ oneDataConTyCon :: TyCon
 omegaDataConTy :: Type
 omegaDataConTyCon :: TyCon
 unrestrictedFunTyCon :: TyCon
+multAddTyCon, multMulTyCon :: TyCon

--- a/compiler/types/TyCon.hs-boot
+++ b/compiler/types/TyCon.hs-boot
@@ -1,8 +1,11 @@
 module TyCon where
 
 import GhcPrelude
+import Unique ( Uniquable )
 
 data TyCon
+
+instance Uniquable TyCon
 
 isTupleTyCon        :: TyCon -> Bool
 isUnboxedTupleTyCon :: TyCon -> Bool

--- a/compiler/types/Type.hs-boot
+++ b/compiler/types/Type.hs-boot
@@ -24,3 +24,4 @@ tyCoVarsOfTypesWellScoped :: [Type] -> [TyCoVar]
 tyCoVarsOfTypeWellScoped :: Type -> [TyCoVar]
 scopedSort :: [TyCoVar] -> [TyCoVar]
 splitTyConApp_maybe :: HasDebugCallStack => Type -> Maybe (TyCon, [Type])
+mkTyConApp :: TyCon -> [Type] -> Type

--- a/libraries/ghc-prim/GHC/Types.hs
+++ b/libraries/ghc-prim/GHC/Types.hs
@@ -43,7 +43,7 @@ module GHC.Types (
         KindRep(..), KindBndr,
 
         -- * Multiplicity Types
-        Multiplicity(..)
+        Multiplicity(..), MultAdd, MultMul
     ) where
 
 import GHC.Prim
@@ -75,6 +75,9 @@ data Constraint
 type Type = TYPE 'LiftedRep
 
 data Multiplicity = Omega | One
+
+type family MultAdd :: Multiplicity -> Multiplicity -> Multiplicity
+type family MultMul :: Multiplicity -> Multiplicity -> Multiplicity
 
 {- *********************************************************************
 *                                                                      *


### PR DESCRIPTION
Refs #60.

Not working yet (#159 might help):
```
λ> comp :: (b -->.(p) c) -> (a -->. (q) b) -> a -->.(MultMul p q) c; comp f g x = f (g x)

<interactive>:3:76: error:
    • Occurs check: cannot construct the infinite type: p ~ MultMul p q
        arising from an application
```

The type from #212:

```data T a where MkT :: a -->.(p) T a```

no longer panics, but it gives ambiguity error, and its type looks weird:

```
λ> :type +v MkT
MkT
  :: forall {p1 :: Multiplicity} {n :: Multiplicity} a
            (p2 :: Multiplicity).
     a -->.(MultMul n p1) T a
```