### PR TITLE
Don't use submultMaybe to compare types

### DIFF
--- a/compiler/types/Type.hs
+++ b/compiler/types/Type.hs
@@ -2632,11 +2632,7 @@ nonDetCmpTypeX env orig_t1 orig_t2 =
     go_mult env r1 r2 =
       if r1 `eqMult` r2
         then TEQ
-        else
-          case submultMaybe r1 r2 of
-            Submult -> TLT
-            NotSubmult  -> TGT
-            Unknown -> go env (fromMult r1) (fromMult r2)
+        else go env (fromMult r1) (fromMult r2)
 
     gos :: RnEnv2 -> [Type] -> [Type] -> TypeOrdering
     gos _   []         []         = TEQ

--- a/compiler/types/Type.hs
+++ b/compiler/types/Type.hs
@@ -2603,7 +2603,7 @@ nonDetCmpTypeX env orig_t1 orig_t2 =
       | Just (s1, t1) <- repSplitAppTy_maybe ty1
       = go env s1 s2 `thenCmpTy` go env t1 t2
     go env (FunTy w1 s1 t1) (FunTy w2 s2 t2)
-      = go_mult env w1 w2 `thenCmpTy`
+      = go env (fromMult w1) (fromMult w2) `thenCmpTy`
         go env s1 s2 `thenCmpTy` go env t1 t2
     go env (TyConApp tc1 tys1) (TyConApp tc2 tys2)
       = liftOrdering (tc1 `nonDetCmpTc` tc2) `thenCmpTy` gos env tys1 tys2
@@ -2627,12 +2627,6 @@ nonDetCmpTypeX env orig_t1 orig_t2 =
             get_rank (FunTy {})      = 6
             get_rank (ForAllTy {})   = 7
 
-
-    go_mult :: RnEnv2 -> Mult -> Mult -> TypeOrdering
-    go_mult env r1 r2 =
-      if r1 `eqMult` r2
-        then TEQ
-        else go env (fromMult r1) (fromMult r2)
 
     gos :: RnEnv2 -> [Type] -> [Type] -> TypeOrdering
     gos _   []         []         = TEQ


### PR DESCRIPTION
`nonDetCmpTypeX` is supposed to be a linear order (for example, it is used as an argument to `sortBy`). 

It was returning "greater" when one multiplicity was not a submultiplicity of another. This feels wrong, since that would make 0 < 1 < 0. (I don't have an example code where this goes wrong.)