### PR TITLE
Instantiate GMult to Type

### DIFF
--- a/compiler/basicTypes/ConLike.hs
+++ b/compiler/basicTypes/ConLike.hs
@@ -35,7 +35,7 @@ import Unique
 import Util
 import Name
 import BasicTypes
-import TyCoRep (Type, ThetaType, Scaled)
+import TyCoRep (Type, ThetaType)
 import Var
 import Type (mkTyConApp)
 import Multiplicity

--- a/compiler/basicTypes/DataCon.hs-boot
+++ b/compiler/basicTypes/DataCon.hs-boot
@@ -8,7 +8,8 @@ import FieldLabel ( FieldLabel )
 import Unique ( Uniquable )
 import Outputable ( Outputable, OutputableBndr )
 import BasicTypes (Arity)
-import {-# SOURCE #-} TyCoRep ( Type, ThetaType, Scaled )
+import {-# SOURCE #-} TyCoRep ( Type, ThetaType )
+import Multiplicity (Scaled)
 
 data DataCon
 data DataConRep

--- a/compiler/basicTypes/Var.hs
+++ b/compiler/basicTypes/Var.hs
@@ -88,7 +88,7 @@ module Var (
 
 import GhcPrelude
 
-import {-# SOURCE #-}   TyCoRep( Type, Kind, pprKind, Mult )
+import {-# SOURCE #-}   TyCoRep( Type, Kind, pprKind )
 import {-# SOURCE #-}   TcType( TcTyVarDetails, pprTcTyVarDetails, vanillaSkolemTv )
 import {-# SOURCE #-}   IdInfo( IdDetails, IdInfo, coVarDetails, isCoVarDetails,
                                 vanillaIdInfo, pprIdDetails )

--- a/compiler/basicTypes/Var.hs-boot
+++ b/compiler/basicTypes/Var.hs-boot
@@ -1,0 +1,12 @@
+module Var where
+
+import GhcPrelude
+import Outputable
+import Data.Data
+
+data Var
+type Id = Var
+type TyVar = Id
+type TyCoVar = Id
+
+data ArgFlag

--- a/compiler/coreSyn/CoreMap.hs
+++ b/compiler/coreSyn/CoreMap.hs
@@ -535,7 +535,7 @@ instance Eq (DeBruijn Type) where
             -> True
         _ -> False
 
-instance (Multable a, Eq (DeBruijn a)) => Eq (DeBruijn (GMult a)) where
+instance Eq (DeBruijn Mult) where
   (D _ One) == (D _ One) = True
   (D _ Omega) == (D _ Omega) = True
   (D env (MultAdd p q)) == (D env' (MultAdd p' q')) = (D env p) == (D env' p') && (D env q) == (D env' q')

--- a/compiler/deSugar/MatchCon.hs
+++ b/compiler/deSugar/MatchCon.hs
@@ -24,7 +24,6 @@ import ConLike
 import BasicTypes ( Origin(..) )
 import TcType
 import Multiplicity
-import Type ( Scaled )
 import DsMonad
 import DsUtils
 import MkCore   ( mkCoreLets )

--- a/compiler/prelude/TysWiredIn.hs-boot
+++ b/compiler/prelude/TysWiredIn.hs-boot
@@ -1,6 +1,6 @@
 module TysWiredIn where
 
-import Var( TyVar, ArgFlag )
+import {-# SOURCE #-} Var( TyVar, ArgFlag )
 import {-# SOURCE #-} TyCon      ( TyCon )
 import {-# SOURCE #-} TyCoRep    (Type, Kind)
 

--- a/compiler/typecheck/TcMatches.hs
+++ b/compiler/typecheck/TcMatches.hs
@@ -30,7 +30,6 @@ import TcRnMonad
 import TcEnv
 import TcPat
 import Multiplicity
-import Type ( Scaled )
 import UsageEnv
 import TcMType
 import TcType

--- a/compiler/typecheck/TcPat.hs
+++ b/compiler/typecheck/TcPat.hs
@@ -34,7 +34,7 @@ import Multiplicity
 import TcEnv
 import TcMType
 import TcValidity( arityErr )
-import Type ( Scaled, pprTyVars )
+import Type ( pprTyVars )
 import TcType
 import TcUnify
 import TcHsType

--- a/compiler/types/TyCoRep.hs
+++ b/compiler/types/TyCoRep.hs
@@ -29,7 +29,6 @@ module TyCoRep (
         KnotTied,
         PredType, ThetaType,      -- Synonyms
         ArgFlag(..),
-        Mult, Scaled,
 
         -- * Coercions
         Coercion(..),
@@ -166,10 +165,9 @@ import {-# SOURCE #-} Type( isPredTy, isCoercionTy, mkAppTy, mkCastTy
                           , tyCoVarsOfTypeWellScoped
                           , tyCoVarsOfTypesWellScoped
                           , scopedSort
-                          , coreView, eqType )
+                          , coreView )
    -- Transitively pulls in a LOT of stuff, better to break the loop
 
-import {-# SOURCE #-} TysWiredIn ( oneDataConTy, omegaDataConTy )
 import {-# SOURCE #-} Coercion
 import {-# SOURCE #-} ConLike ( ConLike(..), conLikeName )
 import {-# SOURCE #-} ToIface( toIfaceTypeX, toIfaceTyLit, toIfaceForAllBndr
@@ -335,24 +333,6 @@ data Type
                     -- GADT data constructor
 
   deriving Data.Data
-
--- | Common short-hands
-type Mult = GMult Type
-type Scaled = GScaled Type
-
-instance Multable Type where
-  fromMult One = oneDataConTy
-  fromMult Omega = omegaDataConTy
-  fromMult (MultThing ty) = ty
-  fromMult _ =
-    pprPanic "Type.fromMult" (text "Full support for multiplicity polymorphism is not implemented yet")
-
-  toMult ty
-    | oneDataConTy `eqType` ty = One
-    | omegaDataConTy `eqType` ty = Omega
-    | otherwise = unsafeMultThing ty
-
-
 
 -- NOTE:  Other parts of the code assume that type literals do not contain
 -- types or type variables.

--- a/compiler/types/TyCoRep.hs-boot
+++ b/compiler/types/TyCoRep.hs-boot
@@ -4,7 +4,6 @@ import GhcPrelude
 
 import Outputable ( Outputable, SDoc )
 import Data.Data  ( Data )
-import Multiplicity
 
 data Type
 data TyThing
@@ -30,7 +29,4 @@ isMultiplicityTy :: Type -> Bool
 instance Data Type
   -- To support Data instances in CoAxiom
 
-type Mult = GMult Type
-type Scaled = GScaled Type
-instance Multable Type
 instance Outputable Type

--- a/compiler/types/Type.hs-boot
+++ b/compiler/types/Type.hs-boot
@@ -3,8 +3,8 @@
 module Type where
 
 import GhcPrelude
-import TyCon
-import Var ( TyCoVar )
+import {-# SOURCE #-} TyCon
+import {-# SOURCE #-} Var ( TyCoVar )
 import {-# SOURCE #-} TyCoRep( Type, Coercion )
 import Util
 

--- a/compiler/types/Unify.hs
+++ b/compiler/types/Unify.hs
@@ -33,7 +33,7 @@ import VarEnv
 import VarSet
 import Name( Name )
 import Type hiding ( getTvSubstEnv )
-import Multiplicity ( Multable(..) )
+import Multiplicity ( fromMult )
 import Coercion hiding ( getCvSubstEnv )
 import TyCon
 import TyCoRep hiding ( getTvSubstEnv, getCvSubstEnv )

--- a/compiler/types/UsageEnv.hs
+++ b/compiler/types/UsageEnv.hs
@@ -7,7 +7,6 @@ import Multiplicity
 import Name
 import NameEnv
 import Outputable
-import TyCoRep ( Mult, Scaled )
 
 --
 -- * Usage environments


### PR DESCRIPTION
Refs #276

Not moving `basicTypes/Multiplicity.hs` yet to avoid conflicts.

This turned out to be harder than expected: I wanted to resolve new import cycles by adding `Multiplicity.hs-boot`, but it's not possible to have pattern synonyms in hs-boot files (https://ghc.haskell.org/trac/ghc/ticket/13322).