### PR TITLE
Unfold newtype wrappers in CoreOpt

### DIFF
--- a/compiler/basicTypes/Id.hs
+++ b/compiler/basicTypes/Id.hs
@@ -69,6 +69,7 @@ module Id (
         isPrimOpId, isPrimOpId_maybe,
         isFCallId, isFCallId_maybe,
         isDataConWorkId, isDataConWorkId_maybe, isDataConWrapId, isDataConId_maybe,
+        isDataConWrapId_maybe,
         idDataCon,
         isConLikeId, isBottomingId, idIsFrom,
         hasNoBinding,
@@ -499,6 +500,11 @@ isDataConWrapId :: Id -> Bool
 isDataConWrapId id = case Var.idDetails id of
                        DataConWrapId _ -> True
                        _               -> False
+
+isDataConWrapId_maybe :: Id -> Maybe DataCon
+isDataConWrapId_maybe id = case Var.idDetails id of
+                        DataConWrapId con -> Just con
+                        _                 -> Nothing
 
 isDataConId_maybe :: Id -> Maybe DataCon
 isDataConId_maybe id = case Var.idDetails id of

--- a/compiler/coreSyn/CoreOpt.hs
+++ b/compiler/coreSyn/CoreOpt.hs
@@ -43,7 +43,7 @@ import Type     hiding ( substTy, extendTvSubst, extendCvSubst, extendTvSubstLis
                        , isInScope, substTyVarBndr, cloneTyVarBndr )
 import Multiplicity
 import Coercion hiding ( substCo, substCoVarBndr )
-import TyCon        ( tyConArity )
+import TyCon        ( tyConArity, isNewTyCon )
 import TysWiredIn
 import PrelNames
 import BasicTypes
@@ -290,6 +290,11 @@ simple_app env (Var v) as
   , isCompulsoryUnfolding (idUnfolding v)
   , isAlwaysActive (idInlineActivation v)
     -- See Note [Unfold compulsory unfoldings in LHSs]
+  = simple_app (soeZapSubst env) (unfoldingTemplate unf) as
+
+  | let unf = idUnfolding v
+  , Just a <- isDataConWrapId_maybe v
+  , isNewTyCon (dataConTyCon a)
   = simple_app (soeZapSubst env) (unfoldingTemplate unf) as
 
   | otherwise

--- a/testsuite/tests/simplCore/should_compile/all.T
+++ b/testsuite/tests/simplCore/should_compile/all.T
@@ -94,7 +94,7 @@ test('T4918', [], makefile_test, ['T4918'])
 # result of -ddump-simpl, which is never advertised to
 # be very stable
 test('T4945',
-     expect_broken(230),
+     normal,
      makefile_test, ['T4945'])
 
 test('T4957',
@@ -112,7 +112,7 @@ test('T5359a', normal, compile, [''])  # Lint error with -O (OccurAnal)
 test('T5359b', normal, compile, [''])  # Lint error with -O (OccurAnal)
 test('T5458', normal, compile, [''])
 test('simpl021', [extra_files(['Simpl021A.hs', 'Simpl021B.hs'])], makefile_test, ['simpl021'])
-test('T5327', expect_broken(235), makefile_test, ['T5327'])
+test('T5327', normal, makefile_test, ['T5327'])
 test('T5615', normal, makefile_test, ['T5615'])
 test('T5623', normal, makefile_test, ['T5623'])
 test('T13155', normal, makefile_test, ['T13155'])

--- a/testsuite/tests/simplCore/should_run/all.T
+++ b/testsuite/tests/simplCore/should_run/all.T
@@ -48,8 +48,8 @@ test('T5453', normal, compile_and_run, [''])
 test('T5441', [], multimod_compile_and_run, ['T5441', ''])
 # This compares Core from integer-gmp
 test('T5603', reqlib('integer-gmp'), compile_and_run, [''])
-test('T2110', expect_broken(241), compile_and_run, [''])
-test('AmapCoerce', expect_broken(241), compile_and_run, [''])
+test('T2110', normal, compile_and_run, [''])
+test('AmapCoerce', normal, compile_and_run, [''])
 
 # Run these tests *without* optimisation too
 test('T5625', [ only_ways(['normal','optasm']), exit_code(1) ], compile_and_run, [''])


### PR DESCRIPTION
Refs #241, #235, #230

Note [Unfold compulsory unfoldings in LHSs] describes that we unfold everything with compulsory unfolding so that `map coerce = coerce` works. I extended this to newtype wrappers. This works, though I'm not 100% sure if it's the right approach.