### PR TITLE
Fix debug build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,6 +117,7 @@ jobs:
       BUILD_SPHINX_PDF: "NO"
       BUILD_SPHINX_HTML: "NO"
       TEST_ENV: x86_64-linux
+      BUILD_FLAVOUR: validate
     steps:
       - checkout
       - *set_git_identity

--- a/compiler/types/OptCoercion.hs
+++ b/compiler/types/OptCoercion.hs
@@ -250,14 +250,15 @@ opt_co4 env sym rep r (ForAllCo tv k_co co)
                             opt_co4_wrap env' sym rep r co
      -- Use the "mk" functions to check for nested Refls
 
-opt_co4 env sym rep r (FunCo _r w co1 co2)
+opt_co4 env sym rep r (FunCo _r cow co1 co2)
   = ASSERT( r == _r )
     if rep
-    then mkFunCo Representational w co1' co2'
-    else mkFunCo r w co1' co2'
+    then mkFunCo Representational cow' co1' co2'
+    else mkFunCo r cow' co1' co2'
   where
     co1' = opt_co4_wrap env sym rep r co1
     co2' = opt_co4_wrap env sym rep r co2
+    cow' = opt_co1 env sym cow
 
 opt_co4 env sym rep r (CoVarCo cv)
   | Just co <- lookupCoVar (lcTCvSubst env) cv


### PR DESCRIPTION
Fixes #317.

We were ignoring multiplicity when optimizing function coercions. On the surface, this wouldn't cause trouble, but the optimizer handles `Sym co` by flipping the Boolean flag `sym`. By not having this call, coercions in multiplicity parameters were not flipped where they should have been.