### PR TITLE
Fix location in 'Enable LinearTypes' message

### DIFF
--- a/compiler/parser/Parser.y
+++ b/compiler/parser/Parser.y
@@ -1967,10 +1967,10 @@ type :: { LHsType GhcPs }
                                        >> ams (sLL $1 $> $ HsFunTy noExt HsUnrestrictedArrow $1 $3)
                                               [mu AnnRarrow $2] }
 
-        | btype '->.' ctype             {% hintLinear (getLoc $1) >>
+        | btype '->.' ctype             {% hintLinear (getLoc $2) >>
                                          ams (sLL $1 $> $ HsFunTy noExt HsLinearArrow $1 $3)
                                              [mu AnnRarrow $2] }
-        | btype '-->.' '(' mult ')' ctype  {% hintLinear (getLoc $1) >>
+        | btype '-->.' '(' mult ')' ctype  {% hintLinear (getLoc $2) >>
                                               ams (sLL $1 $> $ HsFunTy noExt (HsExplicitMult $4) $1 $6)
                                                   [mu AnnRarrow $2] }
 
@@ -1990,15 +1990,15 @@ typedoc :: { LHsType GhcPs }
                                                  HsFunTy noExt HsUnrestrictedArrow
                                                          (cL (comb2 $1 $2) (HsDocTy noExt $1 $2)) $4)
                                                 [mu AnnRarrow $3] }
-        | btype '->.'     ctypedoc       {% hintLinear (getLoc $1) >>
+        | btype '->.'     ctypedoc       {% hintLinear (getLoc $2) >>
                                            ams (sLL $1 $> $ HsFunTy noExt HsLinearArrow $1 $3)
                                                 [mu AnnRarrow $2] }
-        | btype docprev '->.' ctypedoc   {% hintLinear (getLoc $1) >>
+        | btype docprev '->.' ctypedoc   {% hintLinear (getLoc $2) >>
                                            ams (sLL $1 $> $
                                                  HsFunTy noExt HsLinearArrow
                                                          (cL (comb2 $1 $2) (HsDocTy noExt $1 $2)) $4)
                                                 [mu AnnRarrow $3] }
-        | btype '-->.' '(' mult ')' ctypedoc  {% hintLinear (getLoc $1) >>
+        | btype '-->.' '(' mult ')' ctypedoc  {% hintLinear (getLoc $2) >>
                                                  ams (sLL $1 $> $ HsFunTy noExt (HsExplicitMult $4) $1 $6)
                                                      [mu AnnRarrow $2] }
         | docnext btype '->' ctypedoc    {% ams $2 [mu AnnRarrow $3] -- See note [GADT decl discards annotations]

--- a/testsuite/tests/linear/should_fail/LinearNoExt.stderr
+++ b/testsuite/tests/linear/should_fail/LinearNoExt.stderr
@@ -1,3 +1,3 @@
 
-LinearNoExt.hs:3:10: error:
+LinearNoExt.hs:3:12: error:
     Enable LinearTypes to allow linear functions


### PR DESCRIPTION
Before:

```
TestL.hs:3:6: error: Enable LinearTypes to allow linear functions
  |
3 | f :: (Bool->Bool) ->. (Bool->Bool , Bool->Bool)
  |      ^^^^^^^^^^^^
```

After:

```
TestL.hs:3:19: error: Enable LinearTypes to allow linear functions
  |
3 | f :: (Bool->Bool) ->. (Bool->Bool , Bool->Bool)
  |                   ^^^
```