### PR TITLE
Fix lets with signatures

### DIFF
--- a/compiler/typecheck/TcEnv.hs
+++ b/compiler/typecheck/TcEnv.hs
@@ -697,6 +697,7 @@ tcCollectingUsage thing_inside
 tcScalingUsage :: Mult -> TcM a -> TcM a
 tcScalingUsage mult thing_inside
   = do { (usage, result) <- tcCollectingUsage thing_inside
+       ; traceTc "tsScalingUsage" (ppr mult)
        ; tcEmitBindingUsage $ scaleUE mult usage
        ; return result }
 

--- a/compiler/typecheck/TcMatches.hs
+++ b/compiler/typecheck/TcMatches.hs
@@ -93,6 +93,13 @@ tcMatchesFun fn@(L _ fun_name) matches exp_ty
                do { (matches', wrap_fun)
                        <- matchExpectedFunTys herald arity exp_rho $
                           \ pat_tys rhs_ty ->
+                          tcScalingUsage Omega $
+                          -- toplevel bindings and let bindings are, at the
+                          -- moment, always unrestricted. The value being bound
+                          -- must, accordingly, be unrestricted. Hence them
+                          -- being scaled by Omega. When let binders come with a
+                          -- multiplicity, then @tcMatchesFun@ will have to take
+                          -- a multiplicity argument, and scale accordingly.
                           tcMatches match_ctxt pat_tys rhs_ty matches
                   ; return (wrap_fun, matches') }
         ; return (wrap_gen <.> wrap_fun, group) }

--- a/testsuite/tests/linear/should_fail/Linear13.hs
+++ b/testsuite/tests/linear/should_fail/Linear13.hs
@@ -5,6 +5,9 @@ module Linear13 where
 incorrectLet :: a ⊸ ()
 incorrectLet a = let x = a in ()
 
+incorrectLetWithSignature :: (Bool->Bool) ->. ()
+incorrectLetWithSignature x = let y :: Bool->Bool; y = x in ()
+
 incorrectLazyMatch :: (a,b) ⊸ b
 incorrectLazyMatch x = let (a,b) = x in b
 

--- a/testsuite/tests/linear/should_fail/Linear13.stderr
+++ b/testsuite/tests/linear/should_fail/Linear13.stderr
@@ -4,12 +4,21 @@ Linear13.hs:6:14: error:
     • In an equation for ‘incorrectLet’:
           incorrectLet a = let x = a in ()
 
-Linear13.hs:9:20: error:
+Linear13.hs:9:27: error:
+    • Couldn't match expected multiplicity ‘'One’ of variable ‘x’ with actual multiplicity ‘'Omega’
+    • In an equation for ‘incorrectLetWithSignature’:
+          incorrectLetWithSignature x
+            = let
+                y :: Bool -> Bool
+                y = x
+              in ()
+
+Linear13.hs:12:20: error:
     • Couldn't match expected multiplicity ‘'One’ of variable ‘x’ with actual multiplicity ‘'Omega’
     • In an equation for ‘incorrectLazyMatch’:
           incorrectLazyMatch x = let (a, b) = x in b
 
-Linear13.hs:12:24: error:
+Linear13.hs:15:24: error:
     • Couldn't match expected multiplicity ‘'One’ of variable ‘x’ with actual multiplicity ‘'Omega’
     • In an equation for ‘incorrectCasePromotion’:
           incorrectCasePromotion x = case x of { (a, b) -> b }


### PR DESCRIPTION
This moves the let-binder scaling to `tcMatchesFun`, atseems to be used by all the different paths which typecheck let bindings.

(I also snuck in a small debug facility)

This fixes #329