### PR TITLE
Fix assertion failures with unboxed tuples

### DIFF
--- a/compiler/basicTypes/DataCon.hs
+++ b/compiler/basicTypes/DataCon.hs
@@ -1366,16 +1366,12 @@ dataConInstOrigArgTys
 dataConInstOrigArgTys dc@(MkData {dcOrigArgTys = arg_tys,
                                   dcUnivTyVars = univ_tvs,
                                   dcExTyCoVars = ex_tvs}) inst_tys
-  = ASSERT2( tyvars `equalLength` inst_tys2
+  = ASSERT2( tyvars `equalLength` inst_tys
            , text "dataConInstOrigArgTys" <+> ppr dc $$ ppr tyvars $$ ppr inst_tys )
     map (fmap $ substTy subst) arg_tys
   where
     tyvars = univ_tvs ++ ex_tvs
-    inst_tys2 = if isUnboxedTupleCon dc
-                  then map getRuntimeRep inst_tys ++ inst_tys
-                  else inst_tys
-                  -- See Note [Unboxed tuple RuntimeRep vars]
-    subst  = zipTCvSubst tyvars inst_tys2
+    subst  = zipTCvSubst tyvars inst_tys
 
 -- | Returns the argument types of the wrapper, excluding all dictionary arguments
 -- and without substituting for any type variables

--- a/compiler/hsSyn/HsPat.hs
+++ b/compiler/hsSyn/HsPat.hs
@@ -622,8 +622,10 @@ mkPrefixConPat dc pats tys
                       , pat_dicts = []
                       , pat_binds = emptyTcEvBinds
                       , pat_args = PrefixCon pats
-                      , pat_arg_tys = tys
+                      , pat_arg_tys = tys'
                       , pat_wrap = idHsWrapper }
+    where tys' = if isUnboxedTupleCon dc || isUnboxedSumCon dc then map getRuntimeRep tys ++ tys else tys
+          -- See Note [Unboxed tuple RuntimeRep vars]
 
 mkNilPat :: Type -> OutPat (GhcPass p)
 mkNilPat ty = mkPrefixConPat nilDataCon [] [ty]


### PR DESCRIPTION
Refs #335

With this change, we have only one assertion failure caused by linear types: https://circleci.com/gh/tweag/ghc/3582 (additionally, there are assertion failures on master that are fixed in https://gitlab.haskell.org/ghc/ghc/merge_requests/716).

(I don't know why this is not causing trouble on master.)