### PR TITLE
Fix recursive bindings without signatures

### DIFF
--- a/compiler/typecheck/TcBinds.hs
+++ b/compiler/typecheck/TcBinds.hs
@@ -1356,7 +1356,10 @@ tcLhs sig_fn no_gen (FunBind { fun_id = (dL->L nm_loc name)
 
   | otherwise  -- No type signature
   = do { mono_ty <- newOpenFlexiTyVarTy
-       ; mono_id <- newLetBndr no_gen name Alias mono_ty
+       ; mono_id <- newLetBndr no_gen name (Regular Omega) mono_ty
+          -- This ^ generates a binder with Omega multiplicity because all
+          -- let/where-binders are unrestricted. When we introduce linear let
+          -- binders, we will need to retrieve the multiplicity information.
        ; let mono_info = MBI { mbi_poly_name = name
                              , mbi_sig       = Nothing
                              , mbi_mono_id   = mono_id }


### PR DESCRIPTION
The minimal failing example was 

```
f x = g x
g x = f x
```