### PR TITLE
Fix usage of variables in linter

### DIFF
--- a/compiler/coreSyn/CoreLint.hs
+++ b/compiler/coreSyn/CoreLint.hs
@@ -2471,7 +2471,7 @@ addAliasUE id ue thing_inside = LintM $ \ env errs ->
 varCallSiteUsage :: Id -> LintM UsageEnv
 varCallSiteUsage id =
   case varMult id of
-     Regular w -> return (unitUE id w)
+     Regular _ -> return (unitUE id One)
      Alias -> do m <- getUEAliases
                  case lookupNameEnv m (getName id) of
                      Nothing -> do --addErrL (text "bad alias" <+> ppr id)

--- a/compiler/types/Multiplicity.hs
+++ b/compiler/types/Multiplicity.hs
@@ -81,8 +81,7 @@ mkMultMul One p = p
 mkMultMul p One = p
 mkMultMul Omega _ = Omega
 mkMultMul _ Omega = Omega
-mkMultMul p q | p `eqType` q = p
-              | otherwise = mkTyConApp multMulTyCon [p, q]
+mkMultMul p q = mkTyConApp multMulTyCon [p, q]
 
 -- For now, approximate p + q by Omega.
 mkMultAdd :: Mult -> Mult -> Mult


### PR DESCRIPTION
This fixes, in particular, the issue with wrappers with strict
arguments, where the multiplicity of the argument was squared, as far
as the linter was concerned.