### PR TITLE
Don't create non-alias lets in case-of-known-constructor

### DIFF
--- a/compiler/simplCore/Simplify.hs
+++ b/compiler/simplCore/Simplify.hs
@@ -2913,7 +2913,10 @@ knownCon env scrut dc_floats dc dc_ty_args dc_args bndr bs rhs cont
 
     bind_args env' (b:bs') (arg : args)
       = ASSERT( isId b )
-        do { let b' = zap_occ b
+        do { let b' = zap_occ b `setIdVarMult` Alias
+             -- Non-recursive let-binders must be Alias. Especially since they
+             -- are going to be floated.
+             --
              -- Note that the binder might be "dead", because it doesn't
              -- occur in the RHS; and simplNonRecX may therefore discard
              -- it via postInlineUnconditionally.


### PR DESCRIPTION
Fixes
```haskell
{-# LANGUAGE  NoImplicitPrelude, BangPatterns #-}
module Test where

import GHC.Base
import GHC.Num

data  Ratio a = R !a

properFraction      :: (Num a, Num b) => (a -> (a, Integer)) -> Ratio a -> (b, Ratio a)
properFraction quotRem (R x) = let (q, t) = quotRem x in (fromInteger t, R (q+q))

ceiling :: (Num b, Num a) => (a -> (a, Integer)) -> (Ratio a -> a -> Bool) -> Ratio a -> (b, Bool)
ceiling quotRem e x = let !z = 0 in case properFraction quotRem x of (n, r) -> (n,  r `e` z)
```

See #335 .