### PR TITLE
Remove the a*b <= c rule

### DIFF
--- a/compiler/typecheck/TcUnify.hs
+++ b/compiler/typecheck/TcUnify.hs
@@ -816,15 +816,14 @@ tcEqMult eq_orig inst_orig ctxt w_actual w_expected = do
   -- Note that here we do not call to `submult`, so we check
   -- for strict equality.
   ; _wrap <- tc_sub_type_ds eq_orig inst_orig ctxt w_actual w_expected
-  -- I don't know why, but `_wrap` need not be an identity wrapper. At any rate,
-  -- the wrapper isn't significant for multiplicities, so it is safe to drop
-  -- it. But maybe there is a better way to implement this function.
+  -- `_wrap` need not be an identity wrapper. Currently we drop it,
+  -- but this causes Lint failure in the test LinearPolyType.
   ; return () }
 
--- As an approximation to checking w1 * w2 <= w we check that w1 <= w and
--- w2 <= w. As together they imply that w1 * w2 <= w.
+-- As an approximation to p < q we assume p ~ q.
+-- This should be replaced by a solver once we know how to infer
+-- multiplicities.
 tcSubMult :: CtOrigin -> Mult -> Mult -> TcM ()
-tcSubMult o (MultMul m1 m2) w = tcSubMult o m1 w >> tcSubMult o m2 w
 tcSubMult o a_w c_w = tcEqMult o o TypeAppCtxt a_w c_w
 
 

--- a/compiler/types/Multiplicity.hs
+++ b/compiler/types/Multiplicity.hs
@@ -35,8 +35,8 @@ import GhcPrelude
 import Data.Data
 import Outputable
 import {-# SOURCE #-} TyCoRep (Type)
-import {-# SOURCE #-} TysWiredIn ( oneDataConTy, omegaDataConTy, multMulTyCon )
-import {-# SOURCE #-} Type( eqType, splitTyConApp_maybe, mkTyConApp )
+import {-# SOURCE #-} TysWiredIn ( oneDataConTy, omegaDataConTy )
+import {-# SOURCE #-} Type( eqType, splitTyConApp_maybe )
 import PrelNames (multMulTyConKey)
 import Unique (hasKey)
 
@@ -76,12 +76,13 @@ isMultMul ty | Just (tc, [x, y]) <- splitTyConApp_maybe ty
 pattern MultMul :: Mult -> Mult -> Mult
 pattern MultMul p q <- (isMultMul -> Just (p,q))
 
+-- For now, approximate p * q by Omega unless p or q are known to be One.
 mkMultMul :: Mult -> Mult -> Mult
 mkMultMul One p = p
 mkMultMul p One = p
 mkMultMul Omega _ = Omega
 mkMultMul _ Omega = Omega
-mkMultMul p q = mkTyConApp multMulTyCon [p, q]
+mkMultMul _ _ = Omega
 
 -- For now, approximate p + q by Omega.
 mkMultAdd :: Mult -> Mult -> Mult

--- a/testsuite/tests/linear/should_compile/OldList.hs
+++ b/testsuite/tests/linear/should_compile/OldList.hs
@@ -29,6 +29,6 @@ sortBy cmp = []
       | a `cmp` b /= GT = ascending b foo bs
       where
         foo :: [a] -->.(k) [a]
-        foo ys = as (a:ys)
+        foo ys = as (((:) :: a -> [a] ->. [a]) a ys)
     ascending a as bs   = let !x = as [a]
                           in x : sequences bs


### PR DESCRIPTION
Multiplicity multiplication now defaults to Omega.
This fixes the Core Lint issue for OldList; the old code fails to compile.