### PR TITLE
Simplify linearity checking in TcEnv

### DIFF
--- a/compiler/typecheck/TcArrows.hs
+++ b/compiler/typecheck/TcArrows.hs
@@ -379,7 +379,7 @@ tcArrDoStmt env ctxt (RecStmt { recS_stmts = stmts, recS_later_ids = later_names
   = do  { let tup_names = rec_names ++ filterOut (`elem` rec_names) later_names
         ; tup_elt_tys <- newFlexiTyVarTys (length tup_names) liftedTypeKind
         ; let tup_ids = zipWith (\n p -> mkLocalId n Omega p) tup_names tup_elt_tys -- Omega because it's a recursive definition
-        ; tcExtendIdEnv (map unrestricted tup_ids) $ do
+        ; tcExtendIdEnv tup_ids $ do
         { (stmts', tup_rets)
                 <- tcStmtsAndThen ctxt (tcArrDoStmt env) stmts res_ty   $ \ _res_ty' ->
                         -- ToDo: res_ty not really right

--- a/compiler/typecheck/TcBinds.hs
+++ b/compiler/typecheck/TcBinds.hs
@@ -407,7 +407,7 @@ tcValBinds top_lvl binds sigs thing_inside
                 --
                 -- For the moment, let bindings and top-level bindings introduce
                 -- only unrestricted variables.
-        ; tcExtendSigIds top_lvl [unrestricted id | id <- poly_ids] $ do
+        ; tcExtendSigIds top_lvl poly_ids $ do
             { (binds', (extra_binds', thing)) <- tcBindGroups top_lvl sig_fn prag_fn binds $ do
                    { thing <- thing_inside
                      -- See Note [Pattern synonym builders don't yield dependencies]
@@ -505,7 +505,7 @@ tc_group top_lvl sig_fn prag_fn (Recursive, binds) closed thing_inside
     go (scc:sccs) = do  { (binds1, ids1) <- tc_scc scc
                          -- recursive bindings must be unrestricted
                          -- (the ids added to the environment here are the name of the recursive definitions).
-                        ; (binds2, thing) <- tcExtendLetEnv top_lvl sig_fn closed (map unrestricted ids1)
+                        ; (binds2, thing) <- tcExtendLetEnv top_lvl sig_fn closed ids1
                                                             (go sccs)
                         ; return (binds1 `unionBags` binds2, thing) }
     go []         = do  { thing <- thing_inside; return (emptyBag, thing) }
@@ -546,7 +546,7 @@ tc_single top_lvl sig_fn prag_fn lbind closed thing_inside
                                       [lbind]
          -- since we are defining a non-recursive binding, it is not necessary here
          -- to define an unrestricted binding. But we do so until toplevel linear bindings are supported.
-       ; thing <- tcExtendLetEnv top_lvl sig_fn closed (map unrestricted ids) thing_inside
+       ; thing <- tcExtendLetEnv top_lvl sig_fn closed ids thing_inside
        ; return (binds1, thing) }
 
 ------------------------
@@ -1309,7 +1309,7 @@ tcMonoBinds _ sig_fn no_gen binds
 
         ; traceTc "tcMonoBinds" $ vcat [ ppr n <+> ppr id <+> ppr (idType id)
                                        | (n,id) <- rhs_id_env]
-        ; binds' <- tcExtendRecIds (map (fmap unrestricted) rhs_id_env) $
+        ; binds' <- tcExtendRecIds rhs_id_env $
                     mapM (wrapLocM tcRhs) tc_binds
 
         ; return (listToBag binds', mono_infos) }

--- a/compiler/typecheck/TcMatches.hs
+++ b/compiler/typecheck/TcMatches.hs
@@ -534,7 +534,7 @@ tcLcStmt m_tc ctxt (TransStmt { trS_form = form, trS_stmts = stmts
 
        -- Type check the thing in the environment with
        -- these new binders and return the result
-       ; thing <- tcExtendIdEnv (map unrestricted n_bndr_ids) (thing_inside elt_ty)
+       ; thing <- tcExtendIdEnv n_bndr_ids (thing_inside elt_ty)
 
        ; return (TransStmt { trS_stmts = stmts', trS_bndrs = bindersMap'
                            , trS_by = fmap fst by', trS_using = final_using
@@ -715,7 +715,7 @@ tcMcStmt ctxt (TransStmt { trS_stmts = stmts, trS_bndrs = bindersMap
 
        -- Type check the thing in the environment with
        -- these new binders and return the result
-       ; thing <- tcExtendIdEnv (map unrestricted n_bndr_ids) $
+       ; thing <- tcExtendIdEnv n_bndr_ids $
                   thing_inside (mkCheckExpType new_res_ty)
 
        ; return (TransStmt { trS_stmts = stmts', trS_bndrs = bindersMap'
@@ -882,7 +882,7 @@ tcDoStmt ctxt (RecStmt { recS_stmts = stmts, recS_later_ids = later_names
                 -- Omega because it's a recursive definition
               tup_ty  = mkBigCoreTupTy tup_elt_tys
 
-        ; tcExtendIdEnv (map unrestricted tup_ids) $ do
+        ; tcExtendIdEnv tup_ids $ do
         { ((stmts', (ret_op', tup_rets)), stmts_ty)
                 <- tcInferInst $ \ exp_ty ->
                    tcStmtsAndThen ctxt tcDoStmt stmts exp_ty $ \ inner_res_ty ->
@@ -1011,7 +1011,7 @@ tcApplicativeStmts ctxt pairs rhs_ty thing_inside
       -- Bring into scope all the things bound by the args,
       -- and typecheck the thing_inside
       -- See Note [ApplicativeDo and constraints]
-      ; res <- tcExtendIdEnv (map unrestricted $ concatMap get_arg_bndrs args') $
+      ; res <- tcExtendIdEnv (concatMap get_arg_bndrs args') $
                thing_inside body_ty
 
       ; return (zip ops' args', body_ty, res) }

--- a/compiler/typecheck/TcRnDriver.hs
+++ b/compiler/typecheck/TcRnDriver.hs
@@ -137,7 +137,6 @@ import qualified GHC.LanguageExtensions as LangExt
 import Data.Data ( Data )
 import HsDumpAst
 import qualified Data.Set as S
-import Multiplicity
 
 import Control.DeepSeq
 import Control.Monad
@@ -1905,7 +1904,6 @@ runTcInteractive hsc_env thing_inside
       | AnId id <- thing
       , not (isTypeClosedLetBndr id)
       = Left (idName id, ATcId { tct_id = id
-                               , tct_mult = Omega
                                , tct_info = NotLetBound })
       | otherwise
       = Right thing

--- a/compiler/typecheck/TcRnTypes.hs
+++ b/compiler/typecheck/TcRnTypes.hs
@@ -1085,7 +1085,6 @@ data TcTyThing
   | ATcId           -- Ids defined in this module; may not be fully zonked
       { tct_id   :: TcId
       , tct_info :: IdBindingInfo   -- See Note [Meaning of IdBindingInfo]
-      , tct_mult :: Mult
       }
 
   | ATyVar  Name TcTyVar   -- See Note [Type variables in the type environment]

--- a/compiler/typecheck/TcRules.hs
+++ b/compiler/typecheck/TcRules.hs
@@ -163,7 +163,7 @@ generateRuleConstraints ty_bndrs tm_bndrs lhs rhs
               -- the RULE.  c.f. #10072
 
        ; tcExtendTyVarEnv tv_bndrs $
-         tcExtendIdEnv    (map unrestricted id_bndrs) $
+         tcExtendIdEnv    id_bndrs $
     do { -- See Note [Solve order for RULES]
          ((lhs', rule_ty), lhs_wanted) <- captureConstraints (tcInferRho lhs)
        ; (rhs',            rhs_wanted) <- captureConstraints $


### PR DESCRIPTION
Previously, we were calling `tcSubMult` in `tc_extend_local_env`, which is called from many places.

However, it turns out that linearity checking is relevant only from one call site, `tcExtendIdEnv1`; this is the only function that could take non-Omega `ATcId`s. This significantly simplifies the logic, there are less modified functions in the final diff. Furthermore, `tcExtendIdEnv1` is called only from three places, and they can all be modified to take wrappers. This clears the obstacle for the plan of leaving wrappers in places that require multiplicity coercions.

One disadvantage is that `deleteUE` is called less often. I'm not sure whether this is a big problem.