### PR TITLE
WIP on removing lambda binders with unfoldings

### DIFF
--- a/compiler/coreSyn/CoreLint.hs
+++ b/compiler/coreSyn/CoreLint.hs
@@ -931,15 +931,6 @@ checkJoinOcc var n_args
   = return ()
 
 lintLambda :: Var -> LintM (Type, UsageEnv) -> LintM (Type, UsageEnv)
-lintLambda var lintBody | isId var, Just tpl <- maybeUnfoldingTemplate (realIdUnfolding var) =
-  do { let_ue <- lintSingleBinding NotTopLevel NonRecursive (var, tpl)
-     ; addLoc (LambdaBodyOf var) $
-              (lintBinder LambdaBind var $ \var' ->
-                 do { (body_ty, ue) <- addGoodJoins [var] $ addAliasUE var let_ue lintBody
-                    ; return (mkLamType var' body_ty, ue)
-                    })
-     }
-
 lintLambda var lintBody =
     addLoc (LambdaBodyOf var) $
     lintBinder LambdaBind var $ \ var' ->

--- a/compiler/typecheck/TcFlatten.hs
+++ b/compiler/typecheck/TcFlatten.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP, DeriveFunctor, ViewPatterns, BangPatterns #-}
-{-# OPTIONS_GHC -O0 #-}
 
 module TcFlatten(
    FlattenMode(..),

--- a/compiler/typecheck/TcTypeable.hs
+++ b/compiler/typecheck/TcTypeable.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# OPTIONS_GHC -O0 #-}
 
 module TcTypeable(mkTypeableBinds) where
 


### PR DESCRIPTION
WIP on #412. This fixes the bug, but there's remaining work:
- update Note [Case binders and join points]
- update and check Note [Lambda-bound unfoldings] - what else needs to be changed? 
- performance measures?
- possible idea: in DataAlt, if all `bndr'` are dead, pass the case binder directly

This could be pushed to master before linear types.