### PR TITLE
Easier recursive aliases

### DIFF
--- a/compiler/backpack/RnModIface.hs
+++ b/compiler/backpack/RnModIface.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TupleSections #-}
 
 -- | This module implements interface renaming, which is
 -- used to rewrite interface files on the fly when we
@@ -661,8 +662,11 @@ rnIfaceConAlt (IfaceDataAlt data_occ) = IfaceDataAlt <$> rnIfaceGlobal data_occ
 rnIfaceConAlt alt = pure alt
 
 rnIfaceLetBndr :: Rename IfaceLetBndr
-rnIfaceLetBndr (IfLetBndr fs ty info jpi)
-    = IfLetBndr fs <$> rnIfaceType ty <*> rnIfaceIdInfo info <*> pure jpi
+rnIfaceLetBndr (IfLetBndr fs uann ty info jpi)
+    = IfLetBndr fs <$> rnIfaceUAnn uann <*> rnIfaceType ty <*> rnIfaceIdInfo info <*> pure jpi
+
+rnIfaceUAnn :: Rename IfaceUsageAnn
+rnIfaceUAnn (anns, b) = (, b) <$> traverse (\(n,w) -> (n,) <$> rnIfaceType w) anns
 
 rnIfaceLamBndr :: Rename IfaceLamBndr
 rnIfaceLamBndr (bndr, oneshot) = (,) <$> rnIfaceBndr bndr <*> pure oneshot

--- a/compiler/basicTypes/Id.hs
+++ b/compiler/basicTypes/Id.hs
@@ -304,7 +304,7 @@ mkLocalCoVar name ty
 -- | Like 'mkLocalId', but checks the type to see if it should make a covar
 mkLocalIdOrCoVar :: Name -> Mult -> UsageAnnotation -> Type -> Id
 mkLocalIdOrCoVar name w ue ty
-  | isCoVarType ty = ASSERT(eqType w Omega) mkLocalCoVar name   ty
+  | isCoVarType ty = mkLocalCoVar name   ty
   | otherwise      = mkLocalId    name w ue ty
 
 -- | Make a local id, with the IdDetails set to CoVarId if the type indicates

--- a/compiler/basicTypes/MkId.hs
+++ b/compiler/basicTypes/MkId.hs
@@ -45,6 +45,7 @@ import TysWiredIn
 import PrelRules
 import Type
 import Multiplicity
+import UsageEnv
 import FamInstEnv
 import Coercion
 import TcType
@@ -893,7 +894,7 @@ case of a newtype constructor, we simply hardcode its dcr_bangs field to
 -------------------------
 newLocal :: Scaled Type -> UniqSM Var
 newLocal (Scaled w ty) = do { uniq <- getUniqueM
-                            ; return (mkSysLocalOrCoVar (fsLit "dt") uniq w ty) }
+                            ; return (mkSysLocalOrCoVar (fsLit "dt") uniq w zeroUA ty) }
 
 -- | Unpack/Strictness decisions from source module.
 --
@@ -1705,7 +1706,7 @@ voidPrimId  = pcMiscPrelId voidPrimIdName voidPrimTy
                              `setNeverLevPoly`  voidPrimTy)
 
 voidArgId :: Id       -- Local lambda-bound :: Void#
-voidArgId = mkSysLocal (fsLit "void") voidArgIdKey Omega voidPrimTy
+voidArgId = mkSysLocal (fsLit "void") voidArgIdKey Omega zeroUA voidPrimTy
 
 coercionTokenId :: Id         -- :: () ~ ()
 coercionTokenId -- Used to replace Coercion terms when we go to STG

--- a/compiler/basicTypes/NameCache.hs
+++ b/compiler/basicTypes/NameCache.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_GHC -O0 #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE RankNTypes #-}
 

--- a/compiler/basicTypes/Var.hs
+++ b/compiler/basicTypes/Var.hs
@@ -43,14 +43,15 @@ module Var (
 
         -- ** Taking 'Var's apart
         varName, varUnique, varType,
-        varMult, varMultMaybe, varMultDef,
+        varMult, varUsages, varMultMaybe, varMultDef,
         varScaledType,
 
         -- ** Modifying 'Var's
         setVarName, setVarUnique, setVarType,
-        scaleVarBy, setVarMult,
+        scaleVarBy, setVarMult, setVarUsages,
         updateVarTypeButNotMult,
         updateVarTypeAndMult, updateVarTypeAndMultM,
+        updateVarUsages,
 
         -- ** Constructing, taking apart, modifying 'Id's
         mkGlobalVar, mkLocalVar, mkExportedLocalVar, mkCoVar,
@@ -99,6 +100,7 @@ import {-# SOURCE #-}   TcType( TcTyVarDetails, pprTcTyVarDetails, vanillaSkolem
 import {-# SOURCE #-}   IdInfo( IdDetails, IdInfo, coVarDetails, isCoVarDetails,
                                 vanillaIdInfo, pprIdDetails )
 import Multiplicity
+import UsageEnv
 
 import Name hiding (varName)
 import Unique ( Uniquable, Unique, getKey, getUnique
@@ -252,6 +254,7 @@ data Var
         realUnique :: {-# UNPACK #-} !Int,
         varType    :: Type,
         varMult    :: Mult,             -- See Note [Multiplicity of let binders]
+        varUsages  :: UsageAnnotation,
         idScope    :: IdScope,
         id_details :: IdDetails,        -- Stable, doesn't change
         id_info    :: IdInfo }          -- Unstable, updated by simplifier
@@ -321,6 +324,7 @@ instance Outputable Var where
             getPprStyle $ \ppr_style ->
             if |  debugStyle ppr_style && (not (gopt Opt_SuppressVarKinds dflags))
                  -> parens (ppr (varName var) <+> ppr (varMultMaybe var)
+                                              <+> (if isId var then ppr (varUsages var) else empty)
                                               <+> ppr_debug var ppr_style <+>
                           dcolon <+> pprKind (tyVarKind var))
 
@@ -397,23 +401,39 @@ updateVarTypeButNotMult :: (Type -> Type) -> Id -> Id
 updateVarTypeButNotMult f id = id { varType = f (varType id) }
 
 updateVarTypeAndMult :: (Type -> Type) -> Id -> Id
-updateVarTypeAndMult f id = let id' = id { varType = f (varType id) }
-                            in case varMultMaybe id' of
-                                      Just w -> setVarMult id' (f w)
-                                      Nothing -> id'
+updateVarTypeAndMult f id =
+  let
+    id1 = id { varType = f (varType id) }
+    id2 = case varMultMaybe id1 of
+            Just w -> setVarMult id1 (f w)
+            Nothing -> id1
+    id3 = case varUsagesMaybe id2 of
+            Just ua -> setVarUsages id2 (mapUA f ua)
+            Nothing -> id2
+  in id3
 
 updateVarTypeAndMultM :: Monad m => (Type -> m Type) -> Id -> m Id
-updateVarTypeAndMultM f id = do { ty' <- f (varType id)
-                                ; let id' = setVarType id ty'
-                                ; case varMultMaybe id of
-                                    Just w -> do w' <- f w
-                                                 return $ setVarMult id' w'
-                                    Nothing -> return id'
-                                }
+updateVarTypeAndMultM f id = do
+  { ty' <- f (varType id)
+  ; let id1 = setVarType id ty'
+  ; id2 <- case varMultMaybe id of
+             Just w -> do w' <- f w
+                          return $ setVarMult id1 w'
+             Nothing -> return id1
+  ; id3 <- case varUsagesMaybe id2 of
+             Just ua -> do ua' <- traverseUA f ua
+                           return $ setVarUsages id2 ua'
+             Nothing -> return id2
+  ; return id3
+  }
 
 varMultMaybe :: Id -> Maybe Mult
 varMultMaybe (Id { varMult = mult }) = Just mult
 varMultMaybe _ = Nothing
+
+varUsagesMaybe :: Id -> Maybe UsageAnnotation
+varUsagesMaybe (Id { varUsages = ua }) = Just ua
+varUsagesMaybe _ = Nothing
 
 varMultDef :: Id -> Mult
 varMultDef = fromMaybe Omega . varMultMaybe
@@ -437,6 +457,13 @@ scaleVarBy id _ = id
 setVarMult :: Id -> Mult -> Id
 setVarMult id r | isId id = id { varMult = r }
                 | otherwise = pprPanic "setVarMult" (ppr id <+> ppr r)
+
+setVarUsages :: Id -> UsageAnnotation -> Id
+setVarUsages id ua | isId id = id { varUsages = ua }
+                   | otherwise = pprPanic "setVarUsages" (ppr id)
+
+updateVarUsages :: (UsageAnnotation -> UsageAnnotation) -> Id -> Id
+updateVarUsages f id = id { varUsages = f (varUsages id)}
 
 {- *********************************************************************
 *                                                                      *
@@ -709,29 +736,30 @@ idDetails other                         = pprPanic "idDetails" (ppr other)
 -- Ids, because Id.hs uses 'mkGlobalId' etc with different types
 mkGlobalVar :: IdDetails -> Name -> Type -> IdInfo -> Id
 mkGlobalVar details name ty info
-  = mk_id name Omega ty GlobalId details info
+  = mk_id name Omega zeroUA ty GlobalId details info
   -- There is no support for linear global variables yet. They would require
   -- being checked at link-time, which can be useful, but is not a priority.
 
-mkLocalVar :: IdDetails -> Name -> Mult -> Type -> IdInfo -> Id
-mkLocalVar details name w ty info
-  = mk_id name w ty (LocalId NotExported) details  info
+mkLocalVar :: IdDetails -> Name -> Mult -> UsageAnnotation -> Type -> IdInfo -> Id
+mkLocalVar details name w ue ty info
+  = mk_id name w ue ty (LocalId NotExported) details  info
 
 mkCoVar :: Name -> Type -> CoVar
 -- Coercion variables have no IdInfo
-mkCoVar name ty = mk_id name Omega ty (LocalId NotExported) coVarDetails vanillaIdInfo
+mkCoVar name ty = mk_id name Omega zeroUA ty (LocalId NotExported) coVarDetails vanillaIdInfo
 
 -- | Exported 'Var's will not be removed as dead code
 mkExportedLocalVar :: IdDetails -> Name -> Type -> IdInfo -> Id
 mkExportedLocalVar details name ty info
-  = mk_id name Omega ty (LocalId Exported) details info
+  = mk_id name Omega zeroUA ty (LocalId Exported) details info
   -- There is no support for exporting linear variables. See also [mkGlobalVar]
 
-mk_id :: Name -> Mult -> Type -> IdScope -> IdDetails -> IdInfo -> Id
-mk_id name w ty scope details info
+mk_id :: Name -> Mult -> UsageAnnotation -> Type -> IdScope -> IdDetails -> IdInfo -> Id
+mk_id name w ue ty scope details info
   = Id { varName    = name,
          realUnique = getKey (nameUnique name),
          varMult    = w,
+         varUsages  = ue,
          varType    = ty,
          idScope    = scope,
          id_details = details,

--- a/compiler/basicTypes/Var.hs
+++ b/compiler/basicTypes/Var.hs
@@ -458,7 +458,7 @@ setVarMult :: Id -> Mult -> Id
 setVarMult id r | isId id = id { varMult = r }
                 | otherwise = pprPanic "setVarMult" (ppr id <+> ppr r)
 
-setVarUsages :: Id -> UsageAnnotation -> Id
+setVarUsages :: HasCallStack => Id -> UsageAnnotation -> Id
 setVarUsages id ua | isId id = id { varUsages = ua }
                    | otherwise = pprPanic "setVarUsages" (ppr id)
 

--- a/compiler/coreSyn/CoreArity.hs
+++ b/compiler/coreSyn/CoreArity.hs
@@ -30,6 +30,7 @@ import VarEnv
 import Id
 import Type
 import Multiplicity
+import UsageEnv
 import TyCon    ( initRecTc, checkRecTc )
 import Coercion
 import BasicTypes
@@ -1193,5 +1194,5 @@ freshEtaId n subst ty
       where
         Scaled mult' ty' = Type.substScaledTyUnchecked subst ty
         eta_id' = uniqAway (getTCvInScope subst) $
-                  mkSysLocalOrCoVar (fsLit "eta") (mkBuiltinUnique n) mult' ty'
+                  mkSysLocalOrCoVar (fsLit "eta") (mkBuiltinUnique n) mult' zeroUA ty'
         subst'  = extendTCvInScope subst eta_id'

--- a/compiler/coreSyn/CoreLint.hs
+++ b/compiler/coreSyn/CoreLint.hs
@@ -1212,17 +1212,19 @@ lintCoreAlt :: Var              -- Scrut Var
             -> LintM UsageEnv
 -- If you edit this function, you may need to update the GHC formalism
 -- See Note [GHC Formalism]
-lintCoreAlt _ _ _ alt_ty (DEFAULT, args, rhs) =
+lintCoreAlt scrut _ _ alt_ty (DEFAULT, args, rhs) =
   do { lintL (null args) (mkDefaultArgsMsg args)
-     ; lintAltExpr rhs alt_ty }
+     ; rhs_ue <- lintAltExpr rhs alt_ty
+     ; return $ deleteUE rhs_ue scrut }
 
-lintCoreAlt _scrut scrut_ty _ alt_ty (LitAlt lit, args, rhs)
+lintCoreAlt scrut scrut_ty _ alt_ty (LitAlt lit, args, rhs)
   | litIsLifted lit
   = failWithL integerScrutinisedMsg
   | otherwise
   = do { lintL (null args) (mkDefaultArgsMsg args)
        ; ensureEqTys lit_ty scrut_ty (mkBadPatMsg lit_ty scrut_ty)
-       ; lintAltExpr rhs alt_ty }
+       ; rhs_ue <- lintAltExpr rhs alt_ty
+       ; return $ deleteUE rhs_ue scrut }
   where
     lit_ty = literalType lit
 

--- a/compiler/coreSyn/CoreLint.hs
+++ b/compiler/coreSyn/CoreLint.hs
@@ -38,6 +38,7 @@ import TysPrim
 import TcType ( isFloatingTy )
 import Var
 import VarEnv
+import UniqSet ( nonDetEltsUniqSet )
 import VarSet
 import Name
 import Id
@@ -748,6 +749,11 @@ lintCoreExpr (Let (NonRec tv (Type ty)) body)
 lintCoreExpr (Let (NonRec bndr rhs) body)
   | isId bndr
   = do  { let_ue <- lintSingleBinding NotTopLevel NonRecursive (bndr,rhs)
+        ; aliases <- getUEAliases
+        ; let bndr_ua = substUA aliases (varUsages bndr)
+        ; addLoc (RhsOf bndr) $
+                 checkL (validateAnn bndr_ua let_ue)
+                        (invalidUsageAnnotation bndr_ua let_ue)
           -- See Note [Multiplicity of let binders] in Var
         ; addLoc (BodyOfLetRec [bndr]) $
                  (lintBinder LetBind bndr $ \_ ->
@@ -757,7 +763,12 @@ lintCoreExpr (Let (NonRec bndr rhs) body)
 
   | otherwise
   = failWithL (mkLetErr bndr rhs)       -- Not quite accurate
-
+  where
+    -- See Note [Checking annotations in linter]
+    validateAnn ue_ann rhs_ue = compatibleUA ue_ann (mkUA rhs_ue)
+    invalidUsageAnnotation ue_ann rhs_ue =
+      hang (text "Incorrect usage annotation")
+        2 (ppr ue_ann <> ppr (mkUA rhs_ue) <> ppr rhs_ue)
 lintCoreExpr e@(Let (Rec pairs) body)
   = lintLetBndrs NotTopLevel bndrs $
     addGoodJoins bndrs             $
@@ -771,14 +782,38 @@ lintCoreExpr e@(Let (Rec pairs) body)
         ; checkL (all isJoinId bndrs || all (not . isJoinId) bndrs) $
             mkInconsistentRecMsg bndrs
 
+        ; aliases <- getUEAliases
+        ; let ue_anns = map (substUE aliases . interpUA . varUsages) bndrs
+
           -- See Note [Multiplicity of let binders] in Var
-        ; ues <- mapM (lintSingleBinding NotTopLevel Recursive) pairs
-        ; (body_type, body_ue) <- addLoc (BodyOfLetRec bndrs) (lintCoreExpr body)
-        ; return (body_type, body_ue `addUE` scaleUE Omega (foldr1 addUE ues))
+        ; rhs_ues <- addAliasUEs (zip bndrs ue_anns) $
+                     mapM (lintSingleBinding NotTopLevel Recursive) pairs
+        ; addLoc (RhsOf (head bndrs)) $
+            checkL (validateAnns ue_anns rhs_ues)
+                   (invalidUsageAnnotations ue_anns rhs_ues)
+        ; let ues = zipWith supUE rhs_ues ue_anns
+        ; (body_type, body_ue) <- addLoc (BodyOfLetRec bndrs) $
+                                  addAliasUEs (zip bndrs ues) $
+                                  lintCoreExpr body
+        ; return (body_type, body_ue)
         }
   where
     bndrs = map fst pairs
     (_, dups) = removeDups compare bndrs
+    -- Note [Checking annotations in linter]
+    -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    -- We're not checking that annotations are correct in the lintSingleBinding
+    -- at the moment, which would make most sense, because lambda-binding with
+    -- unfolding also use lintSingleBinding to lint the unfolding. And lambda
+    -- binders don't have a usage annotation.
+    validateAnns ue_anns rhs_ues =
+      all
+        (\(ue_ann, rhs_ue) -> compatibleUA (mkUA ue_ann) (mkUA rhs_ue))
+        (zip ue_anns rhs_ues)
+    invalidUsageAnnotations ue_anns rhs_ues =
+      hang (text "Incorrect usage annotations")
+        2 (ppr (map mkUA ue_anns) <> ppr (map mkUA rhs_ues))
+
 
 lintCoreExpr e@(App _ _)
   = addLoc (AnExpr e) $
@@ -2312,7 +2347,14 @@ initL dflags flags in_scope m
              , le_joins = emptyVarSet
              , le_loc = []
              , le_dynflags = dflags
-             , le_ue_aliases = emptyNameEnv }
+             , le_ue_aliases = aliases }
+
+    aliases = mkNameEnv $
+      map
+        (\v -> (getName v, interpUA (varUsages v)))
+        (nonDetEltsUniqSet (getInScopeVars in_scope))
+        -- Determinism is preserved because we are immediately refolding the
+        -- list into a map.
 
 setReportUnsat :: Bool -> LintM a -> LintM a
 -- Switch off lf_report_unsat_syns
@@ -2465,12 +2507,14 @@ addAliasUE id ue thing_inside = LintM $ \ env errs ->
   in
     unLintM thing_inside (env { le_ue_aliases = new_ue_aliases }) errs
 
+addAliasUEs :: [(Id, UsageEnv)] -> LintM a -> LintM a
+addAliasUEs bnds thing_inside =
+  foldl (flip . uncurry $ addAliasUE) thing_inside bnds
+
 varCallSiteUsage :: Id -> LintM UsageEnv
 varCallSiteUsage id =
   do m <- getUEAliases
-     return $ case lookupNameEnv m (getName id) of
-         Nothing -> unitUE id One
-         Just id_ue -> id_ue
+     return $ varCallUsage m id
 
 lintTyCoVarInScope :: TyCoVar -> LintM ()
 lintTyCoVarInScope var

--- a/compiler/coreSyn/CoreTidy.hs
+++ b/compiler/coreSyn/CoreTidy.hs
@@ -23,6 +23,7 @@ import Id
 import IdInfo
 import Demand ( zapUsageEnvSig )
 import Type( tidyType, tidyVarBndr )
+import UsageEnv
 import Coercion( tidyCo )
 import Var
 import VarEnv
@@ -149,8 +150,9 @@ tidyIdBndr env@(tidy_env, var_env) id
         --
         ty'      = tidyType env (idType id)
         mult'    = tidyType env (idMult id)
+        ue'      = mapUA (tidyType env) (varUsages id)
         name'    = mkInternalName (idUnique id) occ' noSrcSpan
-        id'      = mkLocalIdWithInfo name' mult' ty' new_info
+        id'      = mkLocalIdWithInfo name' mult' ue' ty' new_info
         var_env' = extendVarEnv var_env id id'
 
         -- Note [Tidy IdInfo]
@@ -175,9 +177,10 @@ tidyLetBndr rec_tidy_env env@(tidy_env, var_env) (id,rhs)
     let
         ty'      = tidyType env (idType id)
         mult'    = tidyType env (idMult id)
+        ue'      = mapUA (tidyType env) (varUsages id)
         name'    = mkInternalName (idUnique id) occ' noSrcSpan
         details  = idDetails id
-        id'      = mkLocalVar details name' mult' ty' new_info
+        id'      = mkLocalVar details name' mult' ue' ty' new_info
         var_env' = extendVarEnv var_env id id'
 
         -- Note [Tidy IdInfo]

--- a/compiler/coreSyn/CoreUtils.hs
+++ b/compiler/coreSyn/CoreUtils.hs
@@ -24,6 +24,7 @@ module CoreUtils (
 
         -- * Properties of expressions
         exprType, coreAltType, coreAltsType, isExprLevPoly,
+        exprUsageEnv, exprUsageAnnotation, altsUsageEnv, varCallUsage,
         exprIsDupable, exprIsTrivial, getIdFromTrivialExpr, exprIsBottom,
         getIdFromTrivialExpr_maybe,
         exprIsCheap, exprIsExpandable, exprIsCheapX, CheapAppFun,
@@ -80,6 +81,8 @@ import PrelNames( absentErrorIdKey )
 import Type
 import TyCoRep( TyCoBinder(..), TyBinder )
 import Multiplicity
+import UsageEnv
+import NameEnv
 import Coercion
 import TyCon
 import Unique
@@ -144,6 +147,75 @@ coreAltsType :: [CoreAlt] -> Type
 -- ^ Returns the type of the first alternative, which should be the same as for all alternatives
 coreAltsType (alt:_) = coreAltType alt
 coreAltsType []      = panic "corAltsType"
+
+exprUsageEnv :: CoreExpr -> UsageEnv
+exprUsageEnv = exprUsageEnv' emptyNameEnv
+
+exprUsageEnv' :: NameEnv UsageEnv -> CoreExpr -> UsageEnv
+exprUsageEnv' env (Var var) = varCallUsage env var
+exprUsageEnv' _env (Lit _) = zeroUE
+exprUsageEnv' _env (Coercion _) = zeroUE
+exprUsageEnv' env (Let bind body) =
+    exprUsageEnv' (bindUsageEnv env bind) body
+exprUsageEnv' env (Case scrut bnd _ alts) =
+    scrut_ue `addUE` altsUsageEnv env bnd alts
+  where
+    scrut_ue = varMult bnd `scaleUE` exprUsageEnv' env scrut
+exprUsageEnv' env (Cast e _) = exprUsageEnv' env e
+exprUsageEnv' env (Tick _ e) = exprUsageEnv' env e
+exprUsageEnv' env (Lam binder expr) = deleteUE (exprUsageEnv' env expr) binder
+exprUsageEnv' env (App fun (Type _)) =
+    exprUsageEnv' env fun
+exprUsageEnv' env (App fun arg) =
+    exprUsageEnv' env fun `addUE` (arg_mult `scaleUE` exprUsageEnv' env arg)
+  where
+    fun_ty = exprType fun
+    (Scaled arg_mult _, _) = splitFunTy fun_ty
+exprUsageEnv' _ _ = zeroUE
+
+bindUsageEnv :: NameEnv UsageEnv -> CoreBind -> NameEnv UsageEnv
+bindUsageEnv env (NonRec b e) = extendNameEnv env (getName b) (exprUsageEnv' env e)
+bindUsageEnv env (Rec binds) = add_ues (zip bndrs (zipWith supUE ue_anns rhs_ue))
+  where
+    add_ues ues = foldl (\e (b,ue) -> extendNameEnv e (getName b) ue) env ues
+    bndrs = map fst binds
+    rhss = map snd binds
+    ue_anns = interpUA <$> map varUsages bndrs
+    rhs_env = add_ues (zip bndrs ue_anns)
+    rhs_ue = map (exprUsageEnv' rhs_env) rhss
+
+altsUsageEnv :: NameEnv UsageEnv -> CoreBndr -> [CoreAlt] -> UsageEnv
+altsUsageEnv env b alts = supUEs $ map ((`deleteUE` b) . altUsageEnv) alts
+  where
+    altUsageEnv (DEFAULT, _, rhs) = exprUsageEnv' env rhs
+    altUsageEnv (LitAlt _, _, rhs) = exprUsageEnv' env rhs
+    altUsageEnv (DataAlt _, args, rhs) =
+      foldl deleteUE (exprUsageEnv' env rhs) args
+
+exprUsageAnnotation :: CoreExpr -> UsageAnnotation
+exprUsageAnnotation e = mkUA (exprUsageEnv e)
+
+varCallUsage :: NameEnv UsageEnv -> CoreBndr -> UsageEnv
+varCallUsage env var =
+  case lookupNameEnv env (getName var) of
+    Nothing
+      | Omega <- varMult var -> interpUA (varUsages var)
+        -- Note [Keeping track of omega-bound variables]
+        -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        -- Why do we special case `Omega` like this?  If a variable has been
+        -- bound by a lambda with multiplicity Omega, then multiplicity checks
+        -- will always succeed, so we don't need to track their usage.
+        --
+        -- It simplifies desugaring of recursive lets a lot: they are only
+        -- allowed to depend on omega-variables. So they can have an empty usage
+        -- annotation.
+        --
+        -- Additionally, since the vast majority of lambda-binders, in Haskell
+        -- code, are Omega, this is a nice and sweet optimisation.
+      | isGlobalId var -> zeroUE
+      | otherwise -> unitUE var One
+    Just var_ue -> var_ue
+
 
 -- | Is this expression levity polymorphic? This should be the
 -- same as saying (isKindLevPoly . typeKind . exprType) but
@@ -2002,7 +2074,7 @@ dataConInstPat fss uniqs mult con inst_tys
     arg_ids = zipWith4 mk_id_var id_uniqs id_fss arg_tys arg_strs
     mk_id_var uniq fs (Scaled m ty) str
       = setCaseBndrEvald str $  -- See Note [Mark evaluated arguments]
-        mkLocalIdOrCoVar name (mult `mkMultMul` m) (Type.substTy full_subst ty)
+        mkLocalIdOrCoVar name (mult `mkMultMul` m) zeroUA (Type.substTy full_subst ty)
       where
         name = mkInternalName uniq (mkVarOccFS fs) noSrcSpan
 

--- a/compiler/coreSyn/MkCore.hs
+++ b/compiler/coreSyn/MkCore.hs
@@ -67,6 +67,7 @@ import PrelNames
 import HsUtils          ( mkChunkified, chunkify )
 import Type
 import Multiplicity
+import UsageEnv
 import Coercion         ( isCoVar )
 import TysPrim
 import DataCon          ( DataCon, dataConWorkId )
@@ -194,7 +195,7 @@ mkWildEvBinder pred = mkWildValBinder Omega pred
 -- easy to get into difficulties with shadowing.  That's why it is used so little.
 -- See Note [WildCard binders] in SimplEnv
 mkWildValBinder :: Mult -> Type -> Id
-mkWildValBinder w ty = mkLocalIdOrCoVar wildCardName w ty
+mkWildValBinder w ty = mkLocalIdOrCoVar wildCardName w zeroUA ty
 
 mkWildCase :: CoreExpr -> Scaled Type -> Type -> [CoreAlt] -> CoreExpr
 -- Make a case expression whose case binder is unused
@@ -517,7 +518,7 @@ mkTupleCase uniqs vars body scrut_var scrut
 
     one_tuple_case chunk_vars (us, vs, body)
       = let (uniq, us') = takeUniqFromSupply us
-            scrut_var = mkSysLocal (fsLit "ds") uniq Omega
+            scrut_var = mkSysLocal (fsLit "ds") uniq Omega zeroUA
               (mkBoxedTupleTy (map idType chunk_vars))
             body' = mkSmallTupleCase chunk_vars body scrut_var (Var scrut_var)
         in (us', scrut_var:vs, body')
@@ -624,7 +625,7 @@ mkBuildExpr elt_ty mk_build_inside = do
     [n_tyvar] <- newTyVars [alphaTyVar]
     let n_ty = mkTyVarTy n_tyvar
         c_ty = mkVisFunTysOm [elt_ty, n_ty] n_ty
-    [c, n] <- sequence [mkSysLocalM (fsLit "c") Omega c_ty, mkSysLocalM (fsLit "n") Omega n_ty]
+    [c, n] <- sequence [mkSysLocalM (fsLit "c") Omega zeroUA c_ty, mkSysLocalM (fsLit "n") Omega zeroUA n_ty]
 
     build_inside <- mk_build_inside (c, c_ty) (n, n_ty)
 

--- a/compiler/deSugar/Check.hs
+++ b/compiler/deSugar/Check.hs
@@ -55,6 +55,7 @@ import Var           (EvVar)
 import TyCoRep
 import Type
 import Multiplicity
+import UsageEnv
 import UniqSupply
 import DsUtils       (isTrueLHsExpr)
 import qualified GHC.LanguageExtensions as LangExt
@@ -1699,7 +1700,7 @@ mkPmId :: Type -> DsM Id
 mkPmId ty = getUniqueM >>= \unique ->
   let occname = mkVarOccFS $ fsLit "$pm"
       name    = mkInternalName unique occname noSrcSpan
-  in  return (mkLocalId name Omega ty)
+  in  return (mkLocalId name Omega zeroUA ty)
 
 -- | Generate a fresh term variable of a given and return it in two forms:
 -- * A variable pattern
@@ -1865,7 +1866,7 @@ the scrutinee type, SBool z.
 -- * Types and constraints
 
 newEvVar :: Name -> Type -> EvVar
-newEvVar name ty = mkLocalId name Omega ty
+newEvVar name ty = mkLocalId name Omega zeroUA ty
 
 nameType :: String -> Type -> DsM EvVar
 nameType name ty = do

--- a/compiler/deSugar/DsArrows.hs
+++ b/compiler/deSugar/DsArrows.hs
@@ -37,6 +37,7 @@ import {-# SOURCE #-} DsExpr ( dsExpr, dsLExpr, dsLExprNoLP, dsLocalBinds,
 import TcType
 import Type ( splitPiTy )
 import Multiplicity
+import UsageEnv
 import TcEvidence
 import CoreSyn
 import CoreFVs
@@ -107,7 +108,7 @@ mkCmdEnv tc_meths
   where
     mk_bind (std_name, expr)
       = do { rhs <- dsExpr expr
-           ; id <- newSysLocalDs Omega (exprType rhs)
+           ; id <- newSysLocalDs Omega zeroUA (exprType rhs)
            -- no check needed; these are functions
            ; return (NonRec id rhs, (std_name, id)) }
 
@@ -175,18 +176,18 @@ mkFailExpr ctxt ty
 -- construct CoreExpr for \ (a :: a_ty, b :: b_ty) -> a
 mkFstExpr :: Type -> Type -> DsM CoreExpr
 mkFstExpr a_ty b_ty = do
-    a_var <- newSysLocalDs Omega a_ty
-    b_var <- newSysLocalDs Omega b_ty
-    pair_var <- newSysLocalDs Omega (mkCorePairTy a_ty b_ty)
+    a_var <- newSysLocalDs Omega zeroUA a_ty
+    b_var <- newSysLocalDs Omega zeroUA b_ty
+    pair_var <- newSysLocalDs Omega zeroUA (mkCorePairTy a_ty b_ty)
     return (Lam pair_var
                (coreCasePair pair_var a_var b_var (Var a_var)))
 
 -- construct CoreExpr for \ (a :: a_ty, b :: b_ty) -> b
 mkSndExpr :: Type -> Type -> DsM CoreExpr
 mkSndExpr a_ty b_ty = do
-    a_var <- newSysLocalDs Omega a_ty
-    b_var <- newSysLocalDs Omega b_ty
-    pair_var <- newSysLocalDs Omega (mkCorePairTy a_ty b_ty)
+    a_var <- newSysLocalDs Omega zeroUA a_ty
+    b_var <- newSysLocalDs Omega zeroUA b_ty
+    pair_var <- newSysLocalDs Omega zeroUA (mkCorePairTy a_ty b_ty)
     return (Lam pair_var
                (coreCasePair pair_var a_var b_var (Var b_var)))
 
@@ -264,9 +265,9 @@ matchEnvStack   :: [Id]         -- x1..xn
                 -> DsM CoreExpr
 matchEnvStack env_ids stack_id body = do
     uniqs <- newUniqueSupply
-    tup_var <- newSysLocalDs Omega (mkBigCoreVarTupTy env_ids)
+    tup_var <- newSysLocalDs Omega zeroUA (mkBigCoreVarTupTy env_ids)
     let match_env = coreCaseTuple uniqs tup_var env_ids body
-    pair_id <- newSysLocalDs Omega (mkCorePairTy (idType tup_var) (idType stack_id))
+    pair_id <- newSysLocalDs Omega zeroUA (mkCorePairTy (idType tup_var) (idType stack_id))
     return (Lam pair_id (coreCasePair pair_id tup_var stack_id match_env))
 
 ----------------------------------------------
@@ -283,7 +284,7 @@ matchEnv :: [Id]        -- x1..xn
          -> DsM CoreExpr
 matchEnv env_ids body = do
     uniqs <- newUniqueSupply
-    tup_id <- newSysLocalDs Omega (mkBigCoreVarTupTy env_ids)
+    tup_id <- newSysLocalDs Omega zeroUA (mkBigCoreVarTupTy env_ids)
     return (Lam tup_id (coreCaseTuple uniqs tup_id env_ids body))
 
 ----------------------------------------------
@@ -298,7 +299,7 @@ matchVarStack :: [Id] -> Id -> CoreExpr -> DsM (Id, CoreExpr)
 matchVarStack [] stack_id body = return (stack_id, body)
 matchVarStack (param_id:param_ids) stack_id body = do
     (tail_id, tail_code) <- matchVarStack param_ids stack_id body
-    pair_id <- newSysLocalDs Omega (mkCorePairTy (idType param_id) (idType tail_id))
+    pair_id <- newSysLocalDs Omega zeroUA (mkCorePairTy (idType param_id) (idType tail_id))
     return (pair_id, coreCasePair pair_id param_id tail_id tail_code)
 
 mkHsEnvStackExpr :: [Id] -> Id -> LHsExpr GhcTc
@@ -376,7 +377,7 @@ dsCmd ids local_vars stack_ty res_ty
         (_a_ty, arg_ty) = tcSplitAppTy a_arg_ty
     core_arrow <- dsLExprNoLP arrow
     core_arg   <- dsLExpr arg
-    stack_id   <- newSysLocalDs Omega stack_ty
+    stack_id   <- newSysLocalDs Omega zeroUA stack_ty
     core_make_arg <- matchEnvStack env_ids stack_id core_arg
     return (do_premap ids
               (envStackType env_ids stack_ty)
@@ -402,7 +403,7 @@ dsCmd ids local_vars stack_ty res_ty
 
     core_arrow <- dsLExpr arrow
     core_arg   <- dsLExpr arg
-    stack_id   <- newSysLocalDs Omega stack_ty
+    stack_id   <- newSysLocalDs Omega zeroUA stack_ty
     core_make_pair <- matchEnvStack env_ids stack_id
           (mkCorePairExpr core_arrow core_arg)
 
@@ -429,8 +430,8 @@ dsCmd ids local_vars stack_ty res_ty (HsCmdApp _ cmd arg) env_ids = do
         stack_ty' = mkCorePairTy arg_ty stack_ty
     (core_cmd, free_vars, env_ids')
              <- dsfixCmd ids local_vars stack_ty' res_ty cmd
-    stack_id <- newSysLocalDs Omega stack_ty
-    arg_id <- newSysLocalDsNoLP Omega arg_ty
+    stack_id <- newSysLocalDs Omega zeroUA stack_ty
+    arg_id <- newSysLocalDsNoLP Omega zeroUA arg_ty
     -- push the argument expression onto the stack
     let
         stack' = mkCorePairExpr (Var arg_id) (Var stack_id)
@@ -465,8 +466,8 @@ dsCmd ids local_vars stack_ty res_ty
         (pat_tys, stack_ty') = splitTypeAt (length pats) stack_ty
     (core_body, free_vars, env_ids')
        <- dsfixCmd ids local_vars' stack_ty' res_ty body
-    param_ids <- mapM (newSysLocalDsNoLP Omega) pat_tys
-    stack_id' <- newSysLocalDs Omega stack_ty'
+    param_ids <- mapM (newSysLocalDsNoLP Omega zeroUA) pat_tys
+    stack_id' <- newSysLocalDs Omega zeroUA stack_ty'
 
     -- the expression is built from the inside out, so the actions
     -- are presented in reverse order
@@ -508,7 +509,7 @@ dsCmd ids local_vars stack_ty res_ty (HsCmdIf _ mb_fun cond then_cmd else_cmd)
        <- dsfixCmd ids local_vars stack_ty res_ty then_cmd
     (core_else, fvs_else, else_ids)
        <- dsfixCmd ids local_vars stack_ty res_ty else_cmd
-    stack_id   <- newSysLocalDs Omega stack_ty
+    stack_id   <- newSysLocalDs Omega zeroUA stack_ty
     either_con <- dsLookupTyCon eitherTyConName
     left_con   <- dsLookupDataCon leftDataConName
     right_con  <- dsLookupDataCon rightDataConName
@@ -572,7 +573,7 @@ dsCmd ids local_vars stack_ty res_ty
                            , mg_ext = MatchGroupTc arg_tys _
                            , mg_origin = origin }))
       env_ids = do
-    stack_id <- newSysLocalDs Omega stack_ty
+    stack_id <- newSysLocalDs Omega zeroUA stack_ty
 
     -- Extract and desugar the leaf commands in the case, building tuple
     -- expressions that will (after tagging) replace these leaves
@@ -641,7 +642,7 @@ dsCmd ids local_vars stack_ty res_ty (HsCmdLet _ lbinds@(dL->L _ binds) body)
 
     (core_body, _free_vars, env_ids')
        <- dsfixCmd ids local_vars' stack_ty res_ty body
-    stack_id <- newSysLocalDs Omega stack_ty
+    stack_id <- newSysLocalDs Omega zeroUA stack_ty
     -- build a new environment, plus the stack, using the let bindings
     core_binds <- dsLocalBinds lbinds (buildEnvStack env_ids' stack_id)
     -- match the old environment and stack against the input
@@ -712,7 +713,7 @@ dsTrimCmdArg local_vars env_ids
     (meth_binds, meth_ids) <- mkCmdEnv ids
     (core_cmd, free_vars, env_ids')
        <- dsfixCmd meth_ids local_vars stack_ty cmd_ty cmd
-    stack_id <- newSysLocalDs Omega stack_ty
+    stack_id <- newSysLocalDs Omega zeroUA stack_ty
     trim_code
       <- matchEnvStack env_ids stack_id (buildEnvStack env_ids' stack_id)
     let
@@ -784,7 +785,7 @@ dsCmdDo ids local_vars res_ty [dL->L loc (LastStmt _ body _ _)] env_ids = do
                          (text "In the command:" <+> ppr body)
     (core_body, env_ids') <- dsLCmd ids local_vars unitTy res_ty body env_ids
     let env_ty = mkBigCoreVarTupTy env_ids
-    env_var <- newSysLocalDs Omega env_ty
+    env_var <- newSysLocalDs Omega zeroUA env_ty
     let core_map = Lam env_var (mkCorePairExpr (Var env_var) mkCoreUnitExpr)
     return (do_premap ids
                         env_ty
@@ -887,7 +888,7 @@ dsCmdStmt ids local_vars out_ids (BindStmt _ pat cmd _ _) env_ids = do
     -- projection function
     --          \ (p, (xs2)) -> (zs)
 
-    env_id <- newSysLocalDs Omega env_ty2
+    env_id <- newSysLocalDs Omega zeroUA env_ty2
     uniqs <- newUniqueSupply
     let
        after_c_ty = mkCorePairTy pat_ty env_ty2
@@ -898,7 +899,7 @@ dsCmdStmt ids local_vars out_ids (BindStmt _ pat cmd _ _) env_ids = do
     pat_id    <- selectSimpleMatchVarL Omega pat
     match_code
       <- matchSimply (Var pat_id) (StmtCtxt DoExpr) pat body_expr fail_expr
-    pair_id   <- newSysLocalDs Omega after_c_ty
+    pair_id   <- newSysLocalDs Omega zeroUA after_c_ty
     let
         proj_expr = Lam pair_id (coreCasePair pair_id pat_id env_id match_code)
 
@@ -961,7 +962,7 @@ dsCmdStmt ids local_vars out_ids
     -- post_loop_fn = \((later_ids),(env2_ids)) -> (out_ids)
 
     uniqs <- newUniqueSupply
-    env2_id <- newSysLocalDs Omega env2_ty
+    env2_id <- newSysLocalDs Omega zeroUA env2_ty
     let
         later_ty = mkBigCoreVarTupTy later_ids
         post_pair_ty = mkCorePairTy later_ty env2_ty
@@ -1048,7 +1049,7 @@ dsRecCmd ids local_vars stmts later_ids later_rets rec_ids rec_rets = do
 
     -- squash_pair_fn = \ ((env1_ids), ~(rec_ids)) -> (env_ids)
 
-    rec_id <- newSysLocalDs Omega rec_ty
+    rec_id <- newSysLocalDs Omega zeroUA rec_ty
     let
         env1_id_set = fv_stmts `uniqDSetMinusUniqSet` rec_id_set
         env1_ids = dVarSetElems env1_id_set

--- a/compiler/deSugar/DsCCall.hs
+++ b/compiler/deSugar/DsCCall.hs
@@ -33,6 +33,7 @@ import DsUtils
 import TcType
 import Type
 import Multiplicity
+import UsageEnv
 import Id   ( Id )
 import Coercion
 import PrimOp
@@ -149,7 +150,7 @@ unboxArg arg
   | Just tc <- tyConAppTyCon_maybe arg_ty,
     tc `hasKey` boolTyConKey
   = do dflags <- getDynFlags
-       prim_arg <- newSysLocalDs Omega intPrimTy
+       prim_arg <- newSysLocalDs Omega zeroUA intPrimTy
        return (Var prim_arg,
               \ body -> Case (mkWildCase arg (linear arg_ty) intPrimTy
                                        [(DataAlt falseDataCon,[],mkIntLit dflags 0),
@@ -164,8 +165,8 @@ unboxArg arg
   | is_product_type && data_con_arity == 1
   = ASSERT2(isUnliftedType data_con_arg_ty1, pprType arg_ty)
                         -- Typechecker ensures this
-    do case_bndr <- newSysLocalDs Omega arg_ty
-       prim_arg <- newSysLocalDs Omega data_con_arg_ty1
+    do case_bndr <- newSysLocalDs Omega zeroUA arg_ty
+       prim_arg <- newSysLocalDs Omega zeroUA data_con_arg_ty1
        return (Var prim_arg,
                \ body -> Case arg case_bndr (exprType body) [(DataAlt data_con,[prim_arg],body)]
               )
@@ -179,7 +180,7 @@ unboxArg arg
     isJust maybe_arg3_tycon &&
     (arg3_tycon ==  byteArrayPrimTyCon ||
      arg3_tycon ==  mutableByteArrayPrimTyCon)
-  = do case_bndr <- newSysLocalDs Omega arg_ty
+  = do case_bndr <- newSysLocalDs Omega zeroUA arg_ty
        vars@[_l_var, _r_var, arr_cts_var] <- newSysLocalsDs (map unrestricted data_con_arg_tys)
        return (Var arr_cts_var,
                \ body -> Case arg case_bndr (exprType body) [(DataAlt data_con,vars,body)]
@@ -239,7 +240,7 @@ boxResult result_ty
 
         ; (ccall_res_ty, the_alt) <- mk_alt return_result res
 
-        ; state_id <- newSysLocalDs Omega realWorldStatePrimTy
+        ; state_id <- newSysLocalDs Omega zeroUA realWorldStatePrimTy
         ; let io_data_con = head (tyConDataCons io_tycon)
               toIOCon     = dataConWrapId io_data_con
 
@@ -276,7 +277,7 @@ mk_alt :: (Expr Var -> [Expr Var] -> Expr Var)
        -> DsM (Type, (AltCon, [Id], Expr Var))
 mk_alt return_result (Nothing, wrap_result)
   = do -- The ccall returns ()
-       state_id <- newSysLocalDs Omega realWorldStatePrimTy
+       state_id <- newSysLocalDs Omega zeroUA realWorldStatePrimTy
        let
              the_rhs = return_result (Var state_id)
                                      [wrap_result (panic "boxResult")]
@@ -290,8 +291,8 @@ mk_alt return_result (Just prim_res_ty, wrap_result)
   = -- The ccall returns a non-() value
     ASSERT2( isPrimitiveType prim_res_ty, ppr prim_res_ty )
              -- True because resultWrapper ensures it is so
-    do { result_id <- newSysLocalDs Omega prim_res_ty
-       ; state_id <- newSysLocalDs Omega realWorldStatePrimTy
+    do { result_id <- newSysLocalDs Omega zeroUA prim_res_ty
+       ; state_id <- newSysLocalDs Omega zeroUA realWorldStatePrimTy
        ; let the_rhs = return_result (Var state_id)
                                 [wrap_result (Var result_id)]
              ccall_res_ty = mkTupleTy Unboxed [realWorldStatePrimTy, prim_res_ty]

--- a/compiler/deSugar/DsExpr.hs
+++ b/compiler/deSugar/DsExpr.hs
@@ -40,6 +40,7 @@ import TcRnMonad
 import TcHsSyn
 import Type
 import Multiplicity
+import UsageEnv
 import CoreSyn
 import CoreUtils
 import MkCore
@@ -373,7 +374,7 @@ ds_expr _ e@(SectionR _ op expr) = do
     let (x_ty:y_ty:_, _) = splitFunTys (exprType core_op)
         -- See comment with SectionL
     y_core <- dsLExpr expr
-    dsWhenNoErrs (mapM (\(Scaled w ty) -> newSysLocalDsNoLP w ty) [x_ty, y_ty])
+    dsWhenNoErrs (mapM (\(Scaled w ty) -> newSysLocalDsNoLP w zeroUA ty) [x_ty, y_ty])
                  (\[x_id, y_id] -> bindNonRec y_id y_core $
                                    Lam x_id (mkCoreAppsDs (text "sectionr" <+> ppr e)
                                                           core_op [Var x_id, Var y_id]))
@@ -383,7 +384,7 @@ ds_expr _ (ExplicitTuple _ tup_args boxity)
                     -- For every missing expression, we need
                     -- another lambda in the desugaring. This lambda is linear
                     -- since tuples are linear
-               = do { lam_var <- newSysLocalDsNoLP (mkTyVarTy mult) ty
+               = do { lam_var <- newSysLocalDsNoLP (mkTyVarTy mult) zeroUA ty
                     ; return (lam_var : lam_vars, Var lam_var : args, mult:usedmults, mults) }
              go (lam_vars, args, missing, mults) (dL->L _ (Present _ expr))
                     -- Expressions that are present don't generate
@@ -633,7 +634,7 @@ ds_expr _ expr@(RecordUpd { rupd_expr = record_expr, rupd_flds = fields
     ds_field (dL->L _ rec_field)
       = do { rhs <- dsLExpr (hsRecFieldArg rec_field)
            ; let fld_id = unLoc (hsRecUpdFieldId rec_field)
-           ; lcl_id <- newSysLocalDs (idMult fld_id) (idType fld_id)
+           ; lcl_id <- newSysLocalDs (idMult fld_id) zeroUA (idType fld_id)
            ; return (idName fld_id, lcl_id, rhs) }
 
     add_field_binds [] expr = expr

--- a/compiler/deSugar/DsListComp.hs
+++ b/compiler/deSugar/DsListComp.hs
@@ -31,6 +31,7 @@ import CoreUtils
 import Id
 import Type
 import Multiplicity
+import UsageEnv
 import TysWiredIn
 import Match
 import PrelNames
@@ -378,8 +379,8 @@ dfBindComp c_id n_id (pat, core_list1) quals = do
     let b_ty   = idType n_id
 
     -- create some new local id's
-    b <- newSysLocalDs Omega b_ty
-    x <- newSysLocalDs Omega x_ty
+    b <- newSysLocalDs Omega zeroUA b_ty
+    x <- newSysLocalDs Omega zeroUA x_ty
 
     -- build rest of the comprehesion
     core_rest <- dfListComp c_id b quals
@@ -409,11 +410,11 @@ mkZipBind :: [Type] -> DsM (Id, CoreExpr)
 --                              (a2:as'2) -> (a1, a2) : zip as'1 as'2)]
 
 mkZipBind elt_tys = do
-    ass  <- mapM (newSysLocalDs Omega)  elt_list_tys
-    as'  <- mapM (newSysLocalDs Omega)  elt_tys
-    as's <- mapM (newSysLocalDs Omega)  elt_list_tys
+    ass  <- mapM (newSysLocalDs Omega zeroUA)  elt_list_tys
+    as'  <- mapM (newSysLocalDs Omega zeroUA)  elt_tys
+    as's <- mapM (newSysLocalDs Omega zeroUA)  elt_list_tys
 
-    zip_fn <- newSysLocalDs Omega zip_fn_ty
+    zip_fn <- newSysLocalDs Omega zeroUA zip_fn_ty
 
     let inner_rhs = mkConsExpr elt_tuple_ty
                         (mkBigCoreVarTup as')
@@ -448,13 +449,13 @@ mkUnzipBind :: TransForm -> [Type] -> DsM (Maybe (Id, CoreExpr))
 mkUnzipBind ThenForm _
  = return Nothing    -- No unzipping for ThenForm
 mkUnzipBind _ elt_tys
-  = do { ax  <- newSysLocalDs Omega elt_tuple_ty
-       ; axs <- newSysLocalDs Omega elt_list_tuple_ty
-       ; ys  <- newSysLocalDs Omega elt_tuple_list_ty
-       ; xs  <- mapM (newSysLocalDs Omega) elt_tys
-       ; xss <- mapM (newSysLocalDs Omega) elt_list_tys
+  = do { ax  <- newSysLocalDs Omega zeroUA elt_tuple_ty
+       ; axs <- newSysLocalDs Omega zeroUA elt_list_tuple_ty
+       ; ys  <- newSysLocalDs Omega zeroUA elt_tuple_list_ty
+       ; xs  <- mapM (newSysLocalDs Omega zeroUA) elt_tys
+       ; xss <- mapM (newSysLocalDs Omega zeroUA) elt_list_tys
 
-       ; unzip_fn <- newSysLocalDs Omega unzip_fn_ty
+       ; unzip_fn <- newSysLocalDs Omega zeroUA unzip_fn_ty
 
        ; [us1, us2] <- sequence [newUniqueSupply, newUniqueSupply]
 
@@ -558,8 +559,8 @@ dsMcStmt (TransStmt { trS_stmts = stmts, trS_bndrs = bndrs
        ; let tup_n_ty' = mkBigCoreVarTupTy to_bndrs
 
        ; body        <- dsMcStmts stmts_rest
-       ; n_tup_var'  <- newSysLocalDsNoLP Omega n_tup_ty'
-       ; tup_n_var'  <- newSysLocalDs Omega tup_n_ty'
+       ; n_tup_var'  <- newSysLocalDsNoLP Omega zeroUA n_tup_ty'
+       ; tup_n_var'  <- newSysLocalDs Omega zeroUA tup_n_ty'
        ; tup_n_expr' <- mkMcUnzipM form fmap_op n_tup_var' from_bndr_tys
        ; us          <- newUniqueSupply
        ; let rhs'  = mkApps usingExpr' usingArgs'
@@ -608,7 +609,7 @@ matchTuple :: [Id] -> CoreExpr -> DsM CoreExpr
 --  \x. case x of (a,b,c) -> body
 matchTuple ids body
   = do { us <- newUniqueSupply
-       ; tup_id <- newSysLocalDs Omega (mkBigCoreVarTupTy ids)
+       ; tup_id <- newSysLocalDs Omega zeroUA (mkBigCoreVarTupTy ids)
        ; return (Lam tup_id $ mkTupleCase us ids body tup_id (Var tup_id)) }
 
 -- general `rhs' >>= \pat -> stmts` desugaring where `rhs'` is already a
@@ -680,9 +681,9 @@ mkMcUnzipM ThenForm _ ys _
 
 mkMcUnzipM _ fmap_op ys elt_tys
   = do { fmap_op' <- dsExpr fmap_op
-       ; xs       <- mapM (newSysLocalDs Omega) elt_tys
+       ; xs       <- mapM (newSysLocalDs Omega zeroUA) elt_tys
        ; let tup_ty = mkBigCoreTupTy elt_tys
-       ; tup_xs   <- newSysLocalDs Omega tup_ty
+       ; tup_xs   <- newSysLocalDs Omega zeroUA tup_ty
 
        ; let mk_elt i = mkApps fmap_op'  -- fmap :: forall a b. (a -> b) -> n a -> n b
                            [ Type tup_ty, Type (getNth elt_tys i)

--- a/compiler/deSugar/DsMeta.hs
+++ b/compiler/deSugar/DsMeta.hs
@@ -48,6 +48,7 @@ import TcType
 import TyCon
 import TysWiredIn
 import Multiplicity ( pattern Omega )
+import UsageEnv
 import CoreSyn
 import MkCore
 import CoreUtils
@@ -1878,7 +1879,7 @@ mkGenSyms :: [Name] -> DsM [GenSymBind]
 --
 -- Nevertheless, it's monadic because we have to generate nameTy
 mkGenSyms ns = do { var_ty <- lookupType nameTyConName
-                  ; return [(nm, mkLocalId (localiseName nm) Omega var_ty) | nm <- ns] }
+                  ; return [(nm, mkLocalId (localiseName nm) Omega zeroUA var_ty) | nm <- ns] }
 
 
 addBinds :: [GenSymBind] -> DsM a -> DsM a

--- a/compiler/deSugar/DsUtils.hs
+++ b/compiler/deSugar/DsUtils.hs
@@ -248,9 +248,11 @@ wrapBinds ((new,old):prs) e = wrapBind new old (wrapBinds prs e)
 wrapBind :: Var -> Var -> CoreExpr -> CoreExpr
 wrapBind new old body   -- NB: this function must deal with term
   | new==old    = body  -- variables, type variables or coercion variables
-  | otherwise   =
+  | isId new   =
     let new' = new `Var.setVarUsages` (mkUA (unitUE old One)) in
     Let (NonRec new' (varToCoreExpr old)) body
+  | otherwise = Let (NonRec new (varToCoreExpr old)) body
+
 
 seqVar :: Var -> CoreExpr -> CoreExpr
 seqVar var body = Case (Var var) var (exprType body)

--- a/compiler/ghci/ByteCodeGen.hs
+++ b/compiler/ghci/ByteCodeGen.hs
@@ -38,6 +38,7 @@ import Literal
 import PrimOp
 import CoreFVs
 import Multiplicity ( pattern Omega )
+import UsageEnv
 import Type
 import RepType
 import Kind            ( isLiftedTypeKind )
@@ -166,7 +167,7 @@ coreExprToBCOs hsc_env this_mod expr
       -- create a totally bogus name for the top-level BCO; this
       -- should be harmless, since it's never used for anything
       let invented_name  = mkSystemVarName (mkPseudoUniqueE 0) (fsLit "ExprTopLevel")
-          invented_id    = Id.mkLocalId invented_name Omega (panic "invented_id's type")
+          invented_id    = Id.mkLocalId invented_name Omega zeroUA (panic "invented_id's type")
 
       -- the uniques are needed to generate fresh variables when we introduce new
       -- let bindings for ticked expressions
@@ -2029,7 +2030,7 @@ getTopStrings = BcM $ \st -> return (st, topStrings st)
 newId :: Type -> BcM Id
 newId ty = do
     uniq <- newUnique
-    return $ mkSysLocal tickFS uniq Omega ty
+    return $ mkSysLocal tickFS uniq Omega zeroUA ty
 
 tickFS :: FastString
 tickFS = fsLit "ticked"

--- a/compiler/iface/LoadIface.hs
+++ b/compiler/iface/LoadIface.hs
@@ -7,7 +7,7 @@ Loading interface files
 -}
 
 {-# LANGUAGE CPP, BangPatterns, RecordWildCards, NondecreasingIndentation #-}
-{-# OPTIONS_GHC -fno-warn-orphans -O0 #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 module LoadIface (
         -- Importing one thing
         tcLookupImported_maybe, importDecl,

--- a/compiler/iface/MkIface.hs
+++ b/compiler/iface/MkIface.hs
@@ -3,6 +3,7 @@
 (c) The GRASP/AQUA Project, Glasgow University, 1993-1998
 -}
 
+{-# OPTIONS_GHC -fno-worker-wrapper #-}
 {-# LANGUAGE CPP, NondecreasingIndentation #-}
 {-# LANGUAGE MultiWayIf #-}
 

--- a/compiler/iface/ToIface.hs
+++ b/compiler/iface/ToIface.hs
@@ -61,6 +61,7 @@ import Name
 import BasicTypes
 import Type
 import Multiplicity
+import UsageEnv
 import PatSyn
 import Outputable
 import FastString
@@ -394,11 +395,17 @@ toIfaceSrcBang (HsSrcBang _ unpk bang) = IfSrcBang unpk bang
 
 toIfaceLetBndr :: Id -> IfaceLetBndr
 toIfaceLetBndr id  = IfLetBndr (occNameFS (getOccName id))
+                               (toIfaceUAnn (varUsages id))
                                (toIfaceType (idType id))
                                (toIfaceIdInfo (idInfo id))
                                (toIfaceJoinInfo (isJoinId_maybe id))
   -- Put into the interface file any IdInfo that CoreTidy.tidyLetBndr
   -- has left on the Id.  See Note [IdInfo on nested let-bindings] in IfaceSyn
+
+toIfaceUAnn :: UsageAnnotation -> IfaceUsageAnn
+toIfaceUAnn anns = (map (\(n,w) -> (occNameFS (getOccName n), toIfaceType w)) nws, b)
+  where
+    (nws, b) = toListUA anns
 
 toIfaceIdDetails :: IdDetails -> IfaceIdDetails
 toIfaceIdDetails VanillaId                      = IfVanillaId

--- a/compiler/simplCore/OccurAnal.hs
+++ b/compiler/simplCore/OccurAnal.hs
@@ -24,16 +24,18 @@ import GhcPrelude
 import CoreSyn
 import CoreFVs
 import CoreUtils        ( exprIsTrivial, isDefaultAlt, isExpandableApp,
-                          stripTicksTopE, mkTicks )
+                          stripTicksTopE, mkTicks, exprUsageAnnotation )
 import CoreArity        ( joinRhsArity )
 import Id
 import IdInfo
-import Name( localiseName )
+import Name( getName, localiseName )
+import NameEnv
 import BasicTypes
 import Module( Module )
 import Coercion
 import Type
 import Multiplicity
+import UsageEnv
 
 import VarSet
 import VarEnv
@@ -771,7 +773,8 @@ occAnalNonRecBind env lvl imp_rule_edges binder rhs body_usage
   | otherwise                   -- It's mentioned in the body
   = (body_usage' `andUDs` rhs_usage', [NonRec tagged_binder rhs'])
   where
-    (body_usage', tagged_binder) = tagNonRecBinder lvl body_usage binder
+    binder' = updateVarUsages (substUA (occ_usage_subst env)) binder
+    (body_usage', tagged_binder) = tagNonRecBinder lvl body_usage binder'
     mb_join_arity = willBeJoinId_maybe tagged_binder
 
     (bndrs, body) = collectBinders rhs
@@ -1797,8 +1800,9 @@ occAnal env (Case scrut bndr ty alts)
     occ_anal_scrut scrut _alts
         = occAnal (vanillaCtxt env) scrut    -- No need for rhsCtxt
 
-occAnal env (Let bind body)
-  = case occAnal env body                of { (body_usage, body') ->
+occAnal env0 (Let bind body)
+  = let env = gatherAliases env0 bind in
+    case occAnal env body                of { (body_usage, body') ->
     case occAnalBind env NotTopLevel
                      noImpRuleEdges bind
                      body_usage          of { (final_usage, new_binds) ->
@@ -1818,6 +1822,21 @@ occAnalArgs env (arg:args) one_shots
     case occAnal arg_env arg             of { (uds1, arg') ->
     case occAnalArgs env args one_shots' of { (uds2, args') ->
     (uds1 `andUDs` uds2, arg':args') }}}
+
+gatherAliases :: OccEnv -> CoreBind -> OccEnv
+gatherAliases env bind =
+    env { occ_usage_subst =  old_aliases `plusNameEnv` aliases bind }
+  where
+    old_aliases = occ_usage_subst env
+
+    mkAlias :: Id -> UsageEnv
+    mkAlias b = substUE old_aliases (interpUA (varUsages b))
+
+    aliases :: CoreBind -> UsageSubst
+    aliases (NonRec b _) =
+      unitNameEnv (getName b) (mkAlias b)
+    aliases (Rec pairs) = mkNameEnv
+      [ (getName b, mkAlias b) | (b, _) <- pairs ]
 
 {-
 Applications are dealt with specially because we want
@@ -2062,6 +2081,8 @@ data OccEnv
            , occ_rule_act   :: Activation -> Bool   -- Which rules are active
              -- See Note [Finding rule RHS free vars]
 
+           , occ_usage_subst :: UsageSubst
+
            , occ_binder_swap :: !Bool -- enable the binder_swap
              -- See CorePrep Note [Dead code in CorePrep]
     }
@@ -2099,6 +2120,7 @@ initOccEnv
                  -- inlines and rules are active
            , occ_unf_act   = \_ -> True
            , occ_rule_act  = \_ -> True
+           , occ_usage_subst = emptyNameEnv
            , occ_binder_swap = True }
 
 vanillaCtxt :: OccEnv -> OccEnv
@@ -2426,7 +2448,7 @@ mkAltEnv env@(OccEnv { occ_gbl_scrut = pe }) scrut case_bndr
       | isGlobalId v = (env { occ_encl = OccVanilla }, Nothing)
       | otherwise    = ( env { occ_encl = OccVanilla
                              , occ_gbl_scrut = pe `extendVarSet` v }
-                       , Just (localise v, rhs) )
+                       , Just (localise v rhs, rhs) )
       -- ToDO: this isGlobalId stuff is a TEMPORARY FIX
       --       to avoid the binder-swap for GlobalIds
       --       See #16346
@@ -2438,9 +2460,10 @@ mkAltEnv env@(OccEnv { occ_gbl_scrut = pe }) scrut case_bndr
     -- new binding for it, and it might have an External Name, or
     -- even be a GlobalId; Note [Binder swap on GlobalId scrutinees]
     -- Also we don't want any INLINE or NOINLINE pragmas!
-    localise scrut_var = mkLocalIdOrCoVar (localiseName (idName scrut_var))
-                                          (idMult scrut_var)
-                                          (idType scrut_var)
+    localise scrut_var rhs = mkLocalIdOrCoVar (localiseName (idName scrut_var))
+                                              (idMult scrut_var)
+                                              (exprUsageAnnotation rhs)
+                                              (idType scrut_var)
 
 {-
 ************************************************************************

--- a/compiler/simplStg/StgLiftLams/LiftM.hs
+++ b/compiler/simplStg/StgLiftLams/LiftM.hs
@@ -41,6 +41,7 @@ import Util
 import VarEnv
 import VarSet
 import Multiplicity
+import UsageEnv
 
 import Control.Arrow ( second )
 import Control.Monad.Trans.Class
@@ -297,7 +298,7 @@ withLiftedBndr abs_ids bndr inner = do
         -- not be caffy themselves and subsequently will miss a static link
         -- field in their closure. Chaos ensues.
         . flip setIdCafInfo caf_info
-        . mkSysLocalOrCoVar (mkFastString str) uniq Omega
+        . mkSysLocalOrCoVar (mkFastString str) uniq Omega zeroUA
             -- This is a toplevel binders, hence must be Omega
         $ ty
   LiftM $ RWS.local

--- a/compiler/simplStg/UnariseStg.hs
+++ b/compiler/simplStg/UnariseStg.hs
@@ -219,6 +219,7 @@ import UniqSupply
 import Util
 import VarEnv
 import Multiplicity ( pattern Omega )
+import UsageEnv (zeroUA)
 
 import Data.Bifunctor (second)
 import Data.Maybe (mapMaybe)
@@ -731,7 +732,7 @@ mkIds :: FastString -> [UnaryType] -> UniqSM [Id]
 mkIds fs tys = mapM (mkId fs) tys
 
 mkId :: FastString -> UnaryType -> UniqSM Id
-mkId s t = mkSysLocalOrCoVarM s Omega t
+mkId s t = mkSysLocalOrCoVarM s Omega zeroUA t
 
 isMultiValBndr :: Id -> Bool
 isMultiValBndr id

--- a/compiler/stranal/WorkWrap.hs
+++ b/compiler/stranal/WorkWrap.hs
@@ -581,7 +581,7 @@ splitFun dflags fam_envs fn_id fn_info wrap_dmds res_info rhs
               -- worker is join point iff wrapper is join point
               -- (see Note [Don't CPR join points])
 
-            work_id  = mkWorkerId work_uniq fn_id (exprType work_rhs)
+            work_id  = mkWorkerId work_uniq fn_id (varUsages fn_id) (exprType work_rhs)
                         `setIdOccInfo` occInfo fn_info
                                 -- Copy over occurrence info from parent
                                 -- Notably whether it's a loop breaker

--- a/compiler/stranal/WwLib.hs
+++ b/compiler/stranal/WwLib.hs
@@ -31,6 +31,7 @@ import VarEnv           ( mkInScopeSet )
 import VarSet           ( VarSet )
 import Type
 import Multiplicity
+import UsageEnv
 import RepType          ( isVoidTy, typePrimRep )
 import Coercion
 import FamInstEnv
@@ -465,7 +466,7 @@ applyToVars vars fn = mkVarApps fn vars
 
 mk_wrap_arg :: Unique -> Scaled Type -> Demand -> Id
 mk_wrap_arg uniq (Scaled w ty) dmd
-  = mkSysLocalOrCoVar (fsLit "w") uniq w ty
+  = mkSysLocalOrCoVar (fsLit "w") uniq w zeroUA ty
        `setIdDemandInfo` dmd
 
 {- Note [Freshen WW arguments]
@@ -1211,4 +1212,4 @@ mk_ww_local :: Unique -> (Scaled Type, StrictnessMark) -> Id
 -- See Note [Record evaluated-ness in worker/wrapper]
 mk_ww_local uniq (Scaled w ty,str)
   = setCaseBndrEvald str $
-    mkSysLocalOrCoVar (fsLit "ww") uniq w ty
+    mkSysLocalOrCoVar (fsLit "ww") uniq w zeroUA ty

--- a/compiler/typecheck/TcArrows.hs
+++ b/compiler/typecheck/TcArrows.hs
@@ -18,6 +18,7 @@ import HsSyn
 import TcMatches
 import TcHsSyn( hsLPatType )
 import TcType
+import UsageEnv
 import Multiplicity
 import TcMType
 import TcBinds
@@ -378,7 +379,7 @@ tcArrDoStmt env ctxt (RecStmt { recS_stmts = stmts, recS_later_ids = later_names
                             , recS_rec_ids = rec_names }) res_ty thing_inside
   = do  { let tup_names = rec_names ++ filterOut (`elem` rec_names) later_names
         ; tup_elt_tys <- newFlexiTyVarTys (length tup_names) liftedTypeKind
-        ; let tup_ids = zipWith (\n p -> mkLocalId n Omega p) tup_names tup_elt_tys -- Omega because it's a recursive definition
+        ; let tup_ids = zipWith (\n p -> mkLocalId n Omega zeroUA p) tup_names tup_elt_tys -- Omega because it's a recursive definition
         ; tcExtendIdEnv tup_ids $ do
         { (stmts', tup_rets)
                 <- tcStmtsAndThen ctxt (tcArrDoStmt env) stmts res_ty   $ \ _res_ty' ->

--- a/compiler/typecheck/TcBinds.hs
+++ b/compiler/typecheck/TcBinds.hs
@@ -34,6 +34,7 @@ import TcUnify
 import TcSimplify
 import TcEvidence
 import Multiplicity
+import UsageEnv
 import TcHsType
 import TcPat
 import TcMType
@@ -644,7 +645,7 @@ recoveryCode binder_names sig_fn
       , Just poly_id <- completeSigPolyId_maybe sig
       = poly_id
       | otherwise
-      = mkLocalId name Omega forall_a_a
+      = mkLocalId name Omega zeroUA forall_a_a
 
 forall_a_a :: TcType
 -- At one point I had (forall r (a :: TYPE r). a), but of course
@@ -710,7 +711,7 @@ tcPolyCheck prag_fn
 
        ; mono_name <- newNameAt (nameOccName name) nm_loc
        ; ev_vars   <- newEvVars theta
-       ; let mono_id   = mkLocalId mono_name (varMult poly_id) tau
+       ; let mono_id   = mkLocalId mono_name (varMult poly_id) (varUsages poly_id) tau
              skol_info = SigSkol ctxt (idType poly_id) tv_prs
              skol_tvs  = map snd tv_prs
 
@@ -935,7 +936,7 @@ mkInferredPolyId insoluble qtvs inferred_theta poly_name mb_sig_inst mono_ty
          -- do this check; otherwise (#14000) we may report an ambiguity
          -- error for a rather bogus type.
 
-       ; return (mkLocalIdOrCoVar poly_name Omega inferred_poly_ty) }
+       ; return (mkLocalIdOrCoVar poly_name Omega zeroUA inferred_poly_ty) }
 
 
 chooseInferredQuantifiers :: TcThetaType   -- inferred

--- a/compiler/typecheck/TcClassDcl.hs
+++ b/compiler/typecheck/TcClassDcl.hs
@@ -32,6 +32,7 @@ import TcHsType
 import TcMType
 import Type     ( getClassPredTys_maybe, piResultTys )
 import Multiplicity
+import UsageEnv
 import TcType
 import TcRnMonad
 import DriverPhases (HscSource(..))
@@ -275,7 +276,7 @@ tcDefMeth clas tyvars this_dict binds_in hs_sig_fn prag_fn
 
              ctxt = FunSigCtxt sel_name warn_redundant
 
-       ; let local_dm_id = mkLocalId local_dm_name Omega local_dm_ty
+       ; let local_dm_id = mkLocalId local_dm_name Omega zeroUA local_dm_ty
              local_dm_sig = CompleteSig { sig_bndr = local_dm_id
                                         , sig_ctxt  = ctxt
                                         , sig_loc   = getLoc (hsSigType hs_ty) }

--- a/compiler/typecheck/TcExpr.hs
+++ b/compiler/typecheck/TcExpr.hs
@@ -1902,7 +1902,7 @@ tcUnboundId rn_expr unbound res_ty
  = do { ty <- newOpenFlexiTyVarTy  -- Allow Int# etc (#12531)
       ; let occ = unboundVarOcc unbound
       ; name <- newSysName occ
-      ; let ev = mkLocalId name Omega ty
+      ; let ev = mkLocalId name Omega zeroUA ty
       ; can <- newHoleCt (ExprHole unbound) ev ty
       ; emitInsoluble can
       ; tcWrapResultO (UnboundOccurrenceOf occ) rn_expr (HsVar noExtField (noLoc ev))
@@ -2518,7 +2518,7 @@ tcRecordField con_like flds_w_tys (L loc (FieldOcc sel_name lbl)) rhs
         do { rhs' <- tcPolyExprNC rhs field_ty
            ; let field_id = mkUserLocal (nameOccName sel_name)
                                         (nameUnique sel_name)
-                                        Omega field_ty loc
+                                        Omega zeroUA field_ty loc
                 -- Yuk: the field_id has the *unique* of the selector Id
                 --          (so we can find it easily)
                 --      but is a LocalId with the appropriate type of the RHS

--- a/compiler/typecheck/TcForeign.hs
+++ b/compiler/typecheck/TcForeign.hs
@@ -47,6 +47,7 @@ import FamInstEnv
 import Coercion
 import Type
 import Multiplicity
+import UsageEnv
 import ForeignCall
 import ErrUtils
 import Id
@@ -232,7 +233,7 @@ tcFImport (L dloc fo@(ForeignImport { fd_name = L nloc nm, fd_sig_ty = hs_ty
            -- Drop the foralls before inspecting the
            -- structure of the foreign type.
              (arg_tys, res_ty) = tcSplitFunTys (dropForAlls norm_sig_ty)
-             id                = mkLocalId nm Omega sig_ty
+             id                = mkLocalId nm Omega zeroUA sig_ty
                  -- Use a LocalId to obey the invariant that locally-defined
                  -- things are LocalIds.  However, it does not need zonking,
                  -- (so TcHsSyn.zonkForeignExports ignores it).

--- a/compiler/typecheck/TcInstDcls.hs
+++ b/compiler/typecheck/TcInstDcls.hs
@@ -30,6 +30,7 @@ import TcHsSyn
 import TcMType
 import TcType
 import Multiplicity
+import UsageEnv
 import BuildTyCl
 import Inst
 import ClsInst( AssocInstInfo(..), isNotAssociated )
@@ -1268,7 +1269,7 @@ tcSuperClasses dfun_id cls tyvars dfun_evs inst_tys dfun_ev_binds sc_theta
            ; addTcEvBind ev_binds_var $ mkWantedEvBind sc_ev_id sc_ev_tm
            ; let sc_top_ty = mkInvForAllTys tyvars $
                              mkPhiTy (map idType dfun_evs) sc_pred
-                 sc_top_id = mkLocalId sc_top_name Omega sc_top_ty
+                 sc_top_id = mkLocalId sc_top_name Omega zeroUA sc_top_ty
                  export = ABE { abe_ext  = noExtField
                               , abe_wrap = idHsWrapper
                               , abe_poly = sc_top_id
@@ -1743,7 +1744,7 @@ tcMethodBodyHelp hs_sig_fn sel_id local_meth_id meth_bind
                    ; return (sig_ty, hs_wrap) }
 
        ; inner_meth_name <- newName (nameOccName sel_name)
-       ; let inner_meth_id  = mkLocalId inner_meth_name Omega sig_ty
+       ; let inner_meth_id  = mkLocalId inner_meth_name Omega zeroUA sig_ty
              inner_meth_sig = CompleteSig { sig_bndr = inner_meth_id
                                           , sig_ctxt = ctxt
                                           , sig_loc  = getLoc (hsSigType hs_sig_ty) }
@@ -1794,8 +1795,8 @@ mkMethIds clas tyvars dfun_ev_vars inst_tys sel_id
         ; local_meth_name <- newName sel_occ
                   -- Base the local_meth_name on the selector name, because
                   -- type errors from tcMethodBody come from here
-        ; let poly_meth_id  = mkLocalId poly_meth_name  Omega poly_meth_ty
-              local_meth_id = mkLocalId local_meth_name Omega local_meth_ty
+        ; let poly_meth_id  = mkLocalId poly_meth_name  Omega zeroUA poly_meth_ty
+              local_meth_id = mkLocalId local_meth_name Omega zeroUA local_meth_ty
 
         ; return (poly_meth_id, local_meth_id) }
   where

--- a/compiler/typecheck/TcMType.hs
+++ b/compiler/typecheck/TcMType.hs
@@ -119,6 +119,7 @@ import Bag
 import Pair
 import UniqSet
 import Multiplicity
+import UsageEnv
 import qualified GHC.LanguageExtensions as LangExt
 
 import Control.Monad
@@ -169,7 +170,7 @@ newEvVars theta = mapM newEvVar theta
 newEvVar :: TcPredType -> TcRnIf gbl lcl EvVar
 -- Creates new *rigid* variables for predicates
 newEvVar ty = do { name <- newSysName (predTypeOccName ty)
-                 ; return (mkLocalIdOrCoVar name Omega ty) }
+                 ; return (mkLocalIdOrCoVar name Omega zeroUA ty) }
 
 newWanted :: CtOrigin -> Maybe TypeOrKind -> PredType -> TcM CtEvidence
 -- Deals with both equality and non-equality predicates
@@ -280,7 +281,7 @@ emitWantedEvVars orig = mapM (emitWantedEvVar orig)
 newDict :: Class -> [TcType] -> TcM DictId
 newDict cls tys
   = do { name <- newSysName (mkDictOcc (getOccName cls))
-       ; return (mkLocalId name Omega (mkClassPred cls tys)) }
+       ; return (mkLocalId name Omega zeroUA (mkClassPred cls tys)) }
 
 predTypeOccName :: PredType -> OccName
 predTypeOccName ty = case classifyPredType ty of

--- a/compiler/typecheck/TcMatches.hs
+++ b/compiler/typecheck/TcMatches.hs
@@ -524,7 +524,7 @@ tcLcStmt m_tc ctxt (TransStmt { trS_form = form, trS_stmts = stmts
              -- typically something like [(Int,Bool,Int)]
              -- We don't know what tuple_ty is yet, so we use a variable
        ; let mk_n_bndr :: Name -> TcId -> TcId
-             mk_n_bndr n_bndr_name bndr_id = mkLocalIdOrCoVar n_bndr_name Omega (n_app (idType bndr_id))
+             mk_n_bndr n_bndr_name bndr_id = mkLocalIdOrCoVar n_bndr_name Omega zeroUA (n_app (idType bndr_id))
 
              -- Ensure that every old binder of type `b` is linked up with its
              -- new binder which should have type `n b`
@@ -705,7 +705,7 @@ tcMcStmt ctxt (TransStmt { trS_stmts = stmts, trS_bndrs = bindersMap
 
        --------------- Bulding the bindersMap ----------------
        ; let mk_n_bndr :: Name -> TcId -> TcId
-             mk_n_bndr n_bndr_name bndr_id = mkLocalIdOrCoVar n_bndr_name Omega (n_app (idType bndr_id))
+             mk_n_bndr n_bndr_name bndr_id = mkLocalIdOrCoVar n_bndr_name Omega zeroUA (n_app (idType bndr_id))
 
              -- Ensure that every old binder of type `b` is linked up with its
              -- new binder which should have type `n b`
@@ -878,7 +878,7 @@ tcDoStmt ctxt (RecStmt { recS_stmts = stmts, recS_later_ids = later_names
          res_ty thing_inside
   = do  { let tup_names = rec_names ++ filterOut (`elem` rec_names) later_names
         ; tup_elt_tys <- newFlexiTyVarTys (length tup_names) liftedTypeKind
-        ; let tup_ids = zipWith (\n t -> mkLocalId n Omega t) tup_names tup_elt_tys
+        ; let tup_ids = zipWith (\n t -> mkLocalId n Omega zeroUA t) tup_names tup_elt_tys
                 -- Omega because it's a recursive definition
               tup_ty  = mkBigCoreTupTy tup_elt_tys
 

--- a/compiler/typecheck/TcPat.hs
+++ b/compiler/typecheck/TcPat.hs
@@ -31,6 +31,7 @@ import Var
 import Name
 import RdrName
 import Multiplicity
+import UsageEnv
 import TcEnv
 import TcMType
 import TcValidity( arityErr )
@@ -213,7 +214,7 @@ tcPatBndr _ bndr_name pat_ty
   = do { let pat_mult = scaledMult pat_ty
        ; pat_ty <- expTypeToType (scaledThing pat_ty)
        ; traceTc "tcPatBndr(not let)" (ppr bndr_name $$ ppr pat_ty)
-       ; return (idHsWrapper, mkLocalId bndr_name pat_mult pat_ty) }
+       ; return (idHsWrapper, mkLocalId bndr_name pat_mult zeroUA pat_ty) }
                -- Whether or not there is a sig is irrelevant,
                -- as this is local
 
@@ -230,9 +231,9 @@ newLetBndr :: LetBndrSpec -> Name -> Mult -> TcType -> TcM TcId
 --    and we use the original name directly
 newLetBndr LetLclBndr name w ty
   = do { mono_name <- cloneLocalName name
-       ; return (mkLocalId mono_name w ty) }
+       ; return (mkLocalId mono_name w zeroUA ty) }
 newLetBndr (LetGblBndr prags) name w ty
-  = addInlinePrags (mkLocalId name w ty) (lookupPragEnv prags name)
+  = addInlinePrags (mkLocalId name w zeroUA ty) (lookupPragEnv prags name)
 
 tcSubTypePat :: PatEnv -> ExpSigmaType -> TcSigmaType -> TcM HsWrapper
 -- tcSubTypeET with the UserTypeCtxt specialised to GenSigCtxt

--- a/compiler/typecheck/TcPatSyn.hs
+++ b/compiler/typecheck/TcPatSyn.hs
@@ -19,6 +19,7 @@ import GhcPrelude
 import HsSyn
 import TcPat
 import Multiplicity
+import UsageEnv
 import Type( tidyTyCoVarBinders, tidyTypes, tidyType )
 import TcRnMonad
 import TcSigs( emptyPragEnv, completeSigFromId )
@@ -100,7 +101,7 @@ recoverPSB (PSB { psb_id = (dL->L _ name)
        where
          -- The matcher_id is used only by the desugarer, so actually
          -- and error-thunk would probably do just as well here.
-         matcher_id = mkLocalId matcher_name Omega $
+         matcher_id = mkLocalId matcher_name Omega zeroUA $
                       mkSpecForAllTys [alphaTyVar] alphaTy
 
 recoverPSB (XPatSynBind nec) = noExtCon nec

--- a/compiler/typecheck/TcRnMonad.hs
+++ b/compiler/typecheck/TcRnMonad.hs
@@ -647,12 +647,12 @@ newSysName occ
 newSysLocalId :: FastString -> Mult -> TcType -> TcRnIf gbl lcl TcId
 newSysLocalId fs w ty
   = do  { u <- newUnique
-        ; return (mkSysLocalOrCoVar fs u w ty) }
+        ; return (mkSysLocalOrCoVar fs u w zeroUA ty) }
 
 newSysLocalIds :: FastString -> [Scaled TcType] -> TcRnIf gbl lcl [TcId]
 newSysLocalIds fs tys
   = do  { us <- newUniqueSupply
-        ; let mkId' n (Scaled w t) = mkSysLocalOrCoVar fs n w t
+        ; let mkId' n (Scaled w t) = mkSysLocalOrCoVar fs n w zeroUA t
         ; return (zipWith mkId' (uniqsFromSupply us) tys) }
 
 instance MonadUnique (IOEnv (Env gbl lcl)) where

--- a/compiler/typecheck/TcRules.hs
+++ b/compiler/typecheck/TcRules.hs
@@ -27,6 +27,7 @@ import TcEvidence( mkTcCoVarCo )
 import Type
 import TyCon( isTypeFamilyTyCon )
 import Multiplicity
+import UsageEnv
 import Id
 import Var( EvVar )
 import VarSet
@@ -189,7 +190,7 @@ tcRuleTmBndrs [] = return ([],[])
 tcRuleTmBndrs (L _ (RuleBndr _ (L _ name)) : rule_bndrs)
   = do  { ty <- newOpenFlexiTyVarTy
         ; (tyvars, tmvars) <- tcRuleTmBndrs rule_bndrs
-        ; return (tyvars, mkLocalId name Omega ty : tmvars) }
+        ; return (tyvars, mkLocalId name Omega zeroUA ty : tmvars) }
 tcRuleTmBndrs (L _ (RuleBndrSig _ (L _ name) rn_ty) : rule_bndrs)
 --  e.g         x :: a->a
 --  The tyvar 'a' is brought into scope first, just as if you'd written
@@ -198,7 +199,7 @@ tcRuleTmBndrs (L _ (RuleBndrSig _ (L _ name) rn_ty) : rule_bndrs)
 --   error for each out-of-scope type variable used
   = do  { let ctxt = RuleSigCtxt name
         ; (_ , tvs, id_ty) <- tcHsPatSigType ctxt rn_ty
-        ; let id  = mkLocalIdOrCoVar name Omega id_ty
+        ; let id  = mkLocalIdOrCoVar name Omega zeroUA id_ty
                     -- See Note [Pattern signature binders] in TcHsType
 
               -- The type variables scope over subsequent bindings; yuk

--- a/compiler/typecheck/TcSigs.hs
+++ b/compiler/typecheck/TcSigs.hs
@@ -40,6 +40,7 @@ import TcEnv( tcLookupId )
 import TcEvidence( HsWrapper, (<.>) )
 import Type( mkTyVarBinders )
 import Multiplicity
+import UsageEnv
 
 import DynFlags
 import Var      ( TyVar, tyVarKind )
@@ -224,7 +225,7 @@ tcUserTypeSig loc hs_sig_ty mb_name
   = do { sigma_ty <- tcHsSigWcType ctxt_F hs_sig_ty
        ; traceTc "tcuser" (ppr sigma_ty)
        ; return $
-         CompleteSig { sig_bndr  = mkLocalId name Omega sigma_ty
+         CompleteSig { sig_bndr  = mkLocalId name Omega zeroUA sigma_ty
                                    -- We use `Omega' as the multiplicity here,
                                    -- as if this identifier corresponds to
                                    -- anything, it is a top-level

--- a/compiler/typecheck/TcSimplify.hs
+++ b/compiler/typecheck/TcSimplify.hs
@@ -65,6 +65,7 @@ import Data.List          ( partition )
 import Data.List.NonEmpty ( NonEmpty(..) )
 import Maybes             ( isJust )
 import Multiplicity
+import UsageEnv
 
 {-
 *********************************************************************************
@@ -657,7 +658,7 @@ tcNormalise given_ids ty
     mk_wanted_ct = do
       let occ = mkVarOcc "$tcNorm"
       name <- newSysName occ
-      let ev = mkLocalId name Omega ty -- evidences are always unrestricted
+      let ev = mkLocalId name Omega zeroUA ty -- evidences are always unrestricted
           hole = ExprHole $ OutOfScope occ emptyGlobalRdrEnv
       newHoleCt hole ev ty
 


### PR DESCRIPTION
The game plan is:

- All variables are annotated with a list `[(Name, Mult)]` corresponding to the usage environment of their left-hand side.
- This is in addition to the multiplicity annotation, but the intention is that, eventually, lambda-bound variables receive a only a multiplicity, and let-bound variables only a usage environment annotation (sharing the same field).
- This needs to be maintained throughout core-to-core passes (whenever one creates a lambda-bound binder, and in case-of-case for join points (which was the initial motivation)).
- I haven't tried to be efficient.
- Possibly other things I forget.