### PR TITLE
Fix flavor selection

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,8 +3,8 @@ steps:
     agents:
       queue: ghc
     command: |
-      cp mk/build.mk.sample mk/build.mk
-      echo "BuildFlavor = validate" >> mk/build.mk
+      echo "BuildFlavor = validate" > mk/build.mk
+      cat mk/build.mk.sample >> mk/build.mk
       nix-shell --pure --run "./boot && configure_ghc && make -j9"
       mkdir -p test-results
       nix-shell --pure --run "THREADS=9 TEST_ENV=x86_64-linux make test"


### PR DESCRIPTION
The flavor should be set before the instruction which loads the
corresponding settings file is executed.