### PR TITLE
Cache manyDataConTy in mkTyConApp

### DIFF
--- a/compiler/GHC/Core/Type.hs
+++ b/compiler/GHC/Core/Type.hs
@@ -256,6 +256,7 @@ import {-# SOURCE #-} GHC.Builtin.Types
                                  , typeSymbolKind, liftedTypeKind
                                  , liftedTypeKindTyCon
                                  , constraintKind
+                                 , manyDataConTy, manyDataConTyCon
                                  , unrestrictedFunTyCon )
 import GHC.Types.Name( Name )
 import GHC.Builtin.Names
@@ -1271,6 +1272,11 @@ mkTyConApp tycon tys
   | tycon == liftedTypeKindTyCon
   = ASSERT2( null tys, ppr tycon $$ ppr tys )
     liftedTypeKindTyConApp
+  | tycon == manyDataConTyCon
+  -- There are a lot of occurrences of 'Many' so it's a small optimisation to
+  -- avoid reboxing every time `mkTyConApp` is called.
+  = ASSERT2( null tys, ppr tycon $$ ppr tys )
+    manyDataConTy
   | otherwise
   = TyConApp tycon tys
 


### PR DESCRIPTION
This doesn't appear to solve more than ~1% of the extra allocation
from the linear types branch, but it is cheap enough to implement that
it is probably worth it.

The effect is most visible on zonking.