### PR TITLE
Add flag for -XQualifiedDo for #468

### DIFF
--- a/compiler/GHC/Driver/Session.hs
+++ b/compiler/GHC/Driver/Session.hs
@@ -3843,6 +3843,7 @@ xFlagsDeps = [
   flagSpec "QuantifiedConstraints"            LangExt.QuantifiedConstraints,
   flagSpec "PostfixOperators"                 LangExt.PostfixOperators,
   flagSpec "QuasiQuotes"                      LangExt.QuasiQuotes,
+  flagSpec "QualifiedDo"                      LangExt.QualifiedDo,
   flagSpec "Rank2Types"                       LangExt.RankNTypes,
   flagSpec "RankNTypes"                       LangExt.RankNTypes,
   flagSpec "RebindableSyntax"                 LangExt.RebindableSyntax,

--- a/libraries/ghc-boot-th/GHC/LanguageExtensions/Type.hs
+++ b/libraries/ghc-boot-th/GHC/LanguageExtensions/Type.hs
@@ -43,6 +43,7 @@ data Extension
    | Arrows                   -- Arrow-notation syntax
    | TemplateHaskell
    | TemplateHaskellQuotes    -- subset of TH supported by stage1, no splice
+   | QualifiedDo
    | QuasiQuotes
    | ImplicitParams
    | ImplicitPrelude

--- a/testsuite/tests/driver/T4437.hs
+++ b/testsuite/tests/driver/T4437.hs
@@ -40,6 +40,7 @@ expectedGhcOnlyExtensions =
     [ "RelaxedLayout"
     , "AlternativeLayoutRule"
     , "AlternativeLayoutRuleTransitional"
+    , "QualifiedDo"
     ]
 
 expectedCabalOnlyExtensions :: [String]


### PR DESCRIPTION
Adding a flag is dead simple. However, we will need to add it later to the Cabal library, as per [Adding a language extension](https://github.com/ghc/ghc/blob/master/compiler/GHC/Driver/Session.hs#L335). I'll include documentation of the flag on the user guide branch. 