### PR TITLE
Parse qualified do statements

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -89,7 +89,7 @@
 	ignore = untracked
 [submodule "utils/haddock"]
 	path = utils/haddock
-	url = https://gitlab.haskell.org/ghc/haddock.git
+	url = https://gitlab.haskell.org/facundominguez/haddock.git
 	ignore = untracked
 	branch = ghc-head
 [submodule "nofib"]

--- a/compiler/GHC/Parser/Lexer.x
+++ b/compiler/GHC/Parser/Lexer.x
@@ -1392,6 +1392,8 @@ splitQualName :: StringBuffer -> Int -> Bool -> (FastString,FastString)
 -- takes a StringBuffer and a length, and returns the module name
 -- and identifier parts of a qualified name.  Splits at the *last* dot,
 -- because of hierarchical module names.
+--
+-- If the name is not qualified, an empty module name is returned.
 splitQualName orig_buf len parens = split orig_buf orig_buf
   where
     split buf dot_buf
@@ -1411,7 +1413,7 @@ splitQualName orig_buf len parens = split orig_buf orig_buf
        (c,buf') = nextChar buf
 
     done dot_buf =
-        (lexemeToFastString orig_buf (qual_size - 1),
+        (lexemeToFastString orig_buf (max 0 (qual_size - 1)),
          if parens -- Prelude.(+)
             then lexemeToFastString (stepOn dot_buf) (len - qual_size - 2)
             else lexemeToFastString dot_buf (len - qual_size))

--- a/compiler/GHC/Parser/PostProcess.hs
+++ b/compiler/GHC/Parser/PostProcess.hs
@@ -111,6 +111,7 @@ import GHC.Core.ConLike        ( ConLike(..) )
 import GHC.Core.Coercion.Axiom ( Role, fsFromRole )
 import GHC.Types.Name.Reader
 import GHC.Types.Name
+import GHC.Unit.Module (ModuleName)
 import GHC.Types.Basic
 import GHC.Parser.Lexer
 import GHC.Utils.Lexeme ( isLexCon )
@@ -1780,7 +1781,11 @@ class b ~ (Body b) GhcPs => DisambECP b where
          -> Located b
          -> PV (Located b)
   -- | Disambiguate "do { ... }" (do notation)
-  mkHsDoPV :: SrcSpan -> Located [LStmt GhcPs (Located b)] -> PV (Located b)
+  mkHsDoPV ::
+    SrcSpan ->
+    Maybe ModuleName ->
+    Located [LStmt GhcPs (Located b)] ->
+    PV (Located b)
   -- | Disambiguate "( ... )" (parentheses)
   mkHsParPV :: SrcSpan -> Located b -> PV (Located b)
   -- | Disambiguate a variable "f" or a data constructor "MkF".
@@ -1888,7 +1893,8 @@ instance DisambECP (HsCmd GhcPs) where
   mkHsIfPV l c semi1 a semi2 b = do
     checkDoAndIfThenElse c semi1 a semi2 b
     return $ L l (mkHsCmdIf c a b)
-  mkHsDoPV l stmts = return $ L l (HsCmdDo noExtField stmts)
+  mkHsDoPV l Nothing stmts = return $ L l (HsCmdDo noExtField stmts)
+  mkHsDoPV l _       _     = cmdFail l (text "Qualified 'do' in command!")
   mkHsParPV l c = return $ L l (HsCmdPar noExtField c)
   mkHsVarPV (L l v) = cmdFail l (ppr v)
   mkHsLitPV (L l a) = cmdFail l (ppr a)
@@ -1945,7 +1951,7 @@ instance DisambECP (HsExpr GhcPs) where
   mkHsIfPV l c semi1 a semi2 b = do
     checkDoAndIfThenElse c semi1 a semi2 b
     return $ L l (mkHsIf c a b)
-  mkHsDoPV l stmts = return $ L l (HsDo noExtField (DoExpr Nothing) stmts)
+  mkHsDoPV l mod stmts = return $ L l (HsDo noExtField (DoExpr mod) stmts)
   mkHsParPV l e = return $ L l (HsPar noExtField e)
   mkHsVarPV v@(getLoc -> l) = return $ L l (HsVar noExtField v)
   mkHsLitPV (L l a) = return $ L l (HsLit noExtField a)
@@ -2025,7 +2031,7 @@ instance DisambECP (PatBuilder GhcPs) where
   superFunArg m = m
   mkHsAppPV l p1 p2 = return $ L l (PatBuilderApp p1 p2)
   mkHsIfPV l _ _ _ _ _ = addFatalError l $ text "(if ... then ... else ...)-syntax in pattern"
-  mkHsDoPV l _ = addFatalError l $ text "do-notation in pattern"
+  mkHsDoPV l _ _ = addFatalError l $ text "do-notation in pattern"
   mkHsParPV l p = return $ L l (PatBuilderPar p)
   mkHsVarPV v@(getLoc -> l) = return $ L l (PatBuilderVar v)
   mkHsLitPV lit@(L l a) = do


### PR DESCRIPTION
This implements the parser, and makes the module name available for the AST constructors `DoExpr` and `MDoExpr`. I have checked that it builds and parses a few trivial examples, but more rigorous tests are required. 