### PR TITLE
Fix defaulting in printing code

### DIFF
--- a/compiler/GHC/Iface/Type.hs
+++ b/compiler/GHC/Iface/Type.hs
@@ -1009,7 +1009,7 @@ defaultNonStandardVars do_runtimereps do_multiplicities ty = go False emptyFsEnv
       -- See Note [Defaulting RuntimeRep variables], about free vars
       | in_kind && do_runtimereps && GHC.Core.Type.isRuntimeRepTy (tyVarKind tv)
       = liftedRep_ty
-      | in_kind && do_multiplicities && GHC.Core.Type.isMultiplicityTy (tyVarKind tv)
+      | do_multiplicities && GHC.Core.Type.isMultiplicityTy (tyVarKind tv)
       = many_ty
       | otherwise
       = ty

--- a/testsuite/tests/typecheck/should_fail/ExplicitSpecificity2.stderr
+++ b/testsuite/tests/typecheck/should_fail/ExplicitSpecificity2.stderr
@@ -1,6 +1,6 @@
 
 ExplicitSpecificity2.hs:11:15: error:
-    • Cannot apply expression of type ‘Proxy (*) # n0 -> T (*)’
+    • Cannot apply expression of type ‘Proxy (*) -> T (*)’
       to a visible type argument ‘Int’
     • In the expression: C @Type @Int Proxy
       In an equation for ‘x’: x = C @Type @Int Proxy


### PR DESCRIPTION
We, mistakenly, only defaulted in kinds in the `pprType` path.

Closes #486