### PR TITLE
Re-export `FUN` in GHC.Exts

### DIFF
--- a/libraries/base/GHC/Exts.hs
+++ b/libraries/base/GHC/Exts.hs
@@ -30,6 +30,7 @@ module GHC.Exts
         maxTupleSize,
 
         -- * Primitive operations
+        FUN, -- See https://gitlab.haskell.org/ghc/ghc/issues/18302
         module GHC.Prim,
         module GHC.Prim.Ext,
         shiftL#, shiftRL#, iShiftL#, iShiftRA#, iShiftRL#,


### PR DESCRIPTION
Due to https://gitlab.haskell.org/ghc/ghc/issues/18302

I'm not actually sure that this work. It has worked before. But I can't confirm it. I think ghci is doing weird things which are not caught by the build system. I'm going to try a full rebuild.