### PR TITLE
Release notes

### DIFF
--- a/docs/users_guide/8.12.1-notes.rst
+++ b/docs/users_guide/8.12.1-notes.rst
@@ -17,9 +17,8 @@ Highlights
 
   The GADT syntax can be used to define data types with linear and nonlinear fields.
 
-  Note that this extension is considered experimental and the details
-  are subject to change. Further refinement is planned for future versions
-  of GHC.
+This extension is considered experimental: it doesn't implement the full proposal yet and the details
+  are subject to change.
 
 * NCG
 

--- a/docs/users_guide/8.12.1-notes.rst
+++ b/docs/users_guide/8.12.1-notes.rst
@@ -11,13 +11,12 @@ Highlights
 ----------
 
 * The :extension:`LinearTypes` extension enables linear function syntax
-  ``a #-> b``, as described in `Linear Haskell: practical linearity in
-  a higher-order polymorphic language
-  <https://www.microsoft.com/en-us/research/publication/linear-haskell-practical-linearity-higher-order-polymorphic-language/>`__.
+  ``a #-> b``, as described in the `Linear Types GHC proposal
+  <https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0111-linear-types.rst>`__.
 
   The GADT syntax can be used to define data types with linear and nonlinear fields.
 
-This extension is considered experimental: it doesn't implement the full proposal yet and the details
+  This extension is considered experimental: it doesn't implement the full proposal yet and the details
   are subject to change.
 
 * NCG

--- a/docs/users_guide/8.12.1-notes.rst
+++ b/docs/users_guide/8.12.1-notes.rst
@@ -10,6 +10,17 @@ following sections.
 Highlights
 ----------
 
+* The :extension:`LinearTypes` extension enables linear function syntax
+  ``a #-> b``, as described in `Linear Haskell: practical linearity in
+  a higher-order polymorphic language
+  <https://www.microsoft.com/en-us/research/publication/linear-haskell-practical-linearity-higher-order-polymorphic-language/>`__.
+
+  The GADT syntax can be used to define data types with linear and nonlinear fields.
+
+  Note that this extension is considered experimental and the details
+  are subject to change. Further refinement is planned for future versions
+  of GHC.
+
 * NCG
 
   - The linear register allocator saw improvements reducing the number

--- a/docs/users_guide/exts.rst
+++ b/docs/users_guide/exts.rst
@@ -21,7 +21,6 @@ Language extensions
     exts/constraints
     exts/type_signatures
     exts/bindings
-    exts/linear_types
     exts/template_haskell
     exts/strict
     exts/parallel


### PR DESCRIPTION
Also remove the linear types reference: it's already linked in `types.rst` and caused the docs to appear twice.